### PR TITLE
fix(tests): correct mock server validation response format

### DIFF
--- a/.claude/commands/speckit.work_from_issue.md
+++ b/.claude/commands/speckit.work_from_issue.md
@@ -8,7 +8,8 @@ $ARGUMENTS
 
 work on $ARGUMENT autonomously
 
-Workflow - autonomously complete the tasks,
+Workflow - autonomously complete the tasks, follow the steps in each speckit workflow.
+speckit will work from a new branch, the instructions are in the specify step.
 
 0. first confirm the gh issue is valid, when you start mark the issue to in-progress using the label in-progress, update the github issue with comments when you start and finish each speckit stage with a short summary
 1. `/speckit.specify_parent` - Create feature specification from natural language and continue to next stage

--- a/internal/provider/resource_cmdevice_device_mock_test.go
+++ b/internal/provider/resource_cmdevice_device_mock_test.go
@@ -441,6 +441,13 @@ func handleDeviceCreateError(w http.ResponseWriter, req struct {
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{"uuid": "11111111-1111-1111-1111-111111111111"})
 		return
 	}
+	// Handle validation calls - return empty array for success
+	if req.Call == "validateDevice" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("[]"))
+		return
+	}
 	// Fail on addDevice
 	if req.Service == "cmdevice" && req.Call == "addDevice" {
 		http.Error(w, "Failed to create device", http.StatusInternalServerError)
@@ -472,6 +479,13 @@ func handleDeviceCreateInvalidJSON(w http.ResponseWriter, req struct {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{"uuid": "11111111-1111-1111-1111-111111111111"})
+		return
+	}
+	// Handle validation calls - return empty array for success
+	if req.Call == "validateDevice" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("[]"))
 		return
 	}
 	// Return invalid JSON only for addDevice
@@ -508,24 +522,26 @@ func handleDeviceValidationFailure(w http.ResponseWriter, req struct {
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{"uuid": "11111111-1111-1111-1111-111111111111"})
 		return
 	}
-	if req.Service == "cmdevice" && req.Call == "addDevice" {
+	// Handle validation calls - return validation errors in array format
+	if req.Call == "validateDevice" {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
-			"success": false,
-			"validation": []map[string]interface{}{
-				{
-					"field":   "hostname",
-					"message": "Hostname already exists in cluster",
-				},
-				{
-					"field":   "mac",
-					"message": "MAC address is already in use",
-				},
+		_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+			{
+				"Field":    "hostname",
+				"Message":  "Hostname already exists in cluster",
+				"Severity": "ERROR",
+			},
+			{
+				"Field":    "mac",
+				"Message":  "MAC address is already in use",
+				"Severity": "ERROR",
 			},
 		})
 		return
 	}
+	// Default success for other calls (addDevice won't be reached due to validation failure)
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{"success": true})
 }
@@ -552,6 +568,13 @@ func handleDeviceReadError(w http.ResponseWriter, req struct {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{"uuid": "11111111-1111-1111-1111-111111111111"})
+		return
+	}
+	// Handle validation calls - return empty array for success
+	if req.Call == "validateDevice" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("[]"))
 		return
 	}
 	// Allow device creation to succeed
@@ -596,6 +619,13 @@ func handleDeviceReadInvalidJSON(w http.ResponseWriter, req struct {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{"uuid": "11111111-1111-1111-1111-111111111111"})
+		return
+	}
+	// Handle validation calls - return empty array for success
+	if req.Call == "validateDevice" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("[]"))
 		return
 	}
 	// Return success for device creation
@@ -695,7 +725,7 @@ func handleDeviceDeleteError(w http.ResponseWriter, req struct {
 // - Create device without explicit partition attribute (triggers category query for default partition).
 // - Mock BCM API returns HTTP 404 error when calling getCategory.
 // - Provider should detect error and return "Error Querying Category" diagnostic.
-func TestAccCMDeviceDeviceResource_ErrorCategoryNotFound(t *testing.T) {
+func TestAccCMDeviceDeviceResource_MockErrorCategoryNotFound(t *testing.T) {
 	cleanup := clearBCMEnvVars(t)
 	defer cleanup()
 
@@ -726,7 +756,7 @@ func TestAccCMDeviceDeviceResource_ErrorCategoryNotFound(t *testing.T) {
 // - Create device without explicit partition attribute (triggers category query).
 // - Mock BCM API returns malformed JSON when calling getCategory.
 // - Provider should fail to unmarshal response and return "Error Parsing Category" diagnostic.
-func TestAccCMDeviceDeviceResource_ErrorCategoryInvalidJSON(t *testing.T) {
+func TestAccCMDeviceDeviceResource_MockErrorCategoryInvalidJSON(t *testing.T) {
 	cleanup := clearBCMEnvVars(t)
 	defer cleanup()
 
@@ -757,7 +787,7 @@ func TestAccCMDeviceDeviceResource_ErrorCategoryInvalidJSON(t *testing.T) {
 // - Create device without explicit partition attribute.
 // - Mock BCM API returns category with neither partition nor softwareImageProxy fields.
 // - Provider should detect missing partition and return "Missing Partition" diagnostic.
-func TestAccCMDeviceDeviceResource_ErrorCategoryNoPartition(t *testing.T) {
+func TestAccCMDeviceDeviceResource_MockErrorCategoryNoPartition(t *testing.T) {
 	cleanup := clearBCMEnvVars(t)
 	defer cleanup()
 
@@ -787,7 +817,7 @@ func TestAccCMDeviceDeviceResource_ErrorCategoryNoPartition(t *testing.T) {
 // - Create device without explicit partition.
 // - Mock category has softwareImageProxy but missing parentSoftwareImage field.
 // - Provider should return "Missing Partition" with proxy message.
-func TestAccCMDeviceDeviceResource_ErrorCategoryProxyMissingParent(t *testing.T) {
+func TestAccCMDeviceDeviceResource_MockErrorCategoryProxyMissingParent(t *testing.T) {
 	cleanup := clearBCMEnvVars(t)
 	defer cleanup()
 
@@ -821,7 +851,7 @@ func TestAccCMDeviceDeviceResource_ErrorCategoryProxyMissingParent(t *testing.T)
 // - Create device with category using softwareImageProxy (triggers partition query).
 // - Mock BCM API returns HTTP 500 error when calling getPartitions.
 // - Provider should detect error and return "Error Querying Partitions" diagnostic.
-func TestAccCMDeviceDeviceResource_ErrorPartitionsQueryFailed(t *testing.T) {
+func TestAccCMDeviceDeviceResource_MockErrorPartitionsQueryFailed(t *testing.T) {
 	cleanup := clearBCMEnvVars(t)
 	defer cleanup()
 
@@ -851,7 +881,7 @@ func TestAccCMDeviceDeviceResource_ErrorPartitionsQueryFailed(t *testing.T) {
 // - Create device with category using softwareImageProxy.
 // - Mock BCM API returns malformed JSON when calling getPartitions.
 // - Provider should fail to unmarshal and return "Error Parsing Partitions" diagnostic.
-func TestAccCMDeviceDeviceResource_ErrorPartitionsInvalidJSON(t *testing.T) {
+func TestAccCMDeviceDeviceResource_MockErrorPartitionsInvalidJSON(t *testing.T) {
 	cleanup := clearBCMEnvVars(t)
 	defer cleanup()
 
@@ -881,7 +911,7 @@ func TestAccCMDeviceDeviceResource_ErrorPartitionsInvalidJSON(t *testing.T) {
 // - Create device with category using softwareImageProxy.
 // - Mock BCM API returns partitions list without "base" partition.
 // - Provider should return "Missing Base Partition" diagnostic.
-func TestAccCMDeviceDeviceResource_ErrorPartitionsNoBase(t *testing.T) {
+func TestAccCMDeviceDeviceResource_MockErrorPartitionsNoBase(t *testing.T) {
 	cleanup := clearBCMEnvVars(t)
 	defer cleanup()
 
@@ -911,7 +941,7 @@ func TestAccCMDeviceDeviceResource_ErrorPartitionsNoBase(t *testing.T) {
 // - Create device with category having direct partition reference.
 // - Mock BCM API always returns error for getSoftwareImage (partition never commits).
 // - Provider should retry with exponential backoff and return "Partition Not Ready" after 20 retries.
-func TestAccCMDeviceDeviceResource_ErrorPartitionNotCommitted(t *testing.T) {
+func TestAccCMDeviceDeviceResource_MockErrorPartitionNotCommitted(t *testing.T) {
 	cleanup := clearBCMEnvVars(t)
 	defer cleanup()
 
@@ -945,7 +975,7 @@ func TestAccCMDeviceDeviceResource_ErrorPartitionNotCommitted(t *testing.T) {
 // - Create device with valid configuration.
 // - Mock BCM API returns HTTP 500 error when calling addDevice.
 // - Provider should detect error and return "Error Creating Device" diagnostic.
-func TestAccCMDeviceDeviceResource_ErrorDeviceCreateFailed(t *testing.T) {
+func TestAccCMDeviceDeviceResource_MockErrorDeviceCreateFailed(t *testing.T) {
 	cleanup := clearBCMEnvVars(t)
 	defer cleanup()
 
@@ -976,7 +1006,7 @@ func TestAccCMDeviceDeviceResource_ErrorDeviceCreateFailed(t *testing.T) {
 // - Mock BCM API returns malformed JSON from addDevice.
 // - bcm_client.parseErrorResponse detects invalid JSON and returns parse error.
 // - Provider returns "Error Creating Device" diagnostic with parse error details.
-func TestAccCMDeviceDeviceResource_ErrorDeviceCreateInvalidJSON(t *testing.T) {
+func TestAccCMDeviceDeviceResource_MockErrorDeviceCreateInvalidJSON(t *testing.T) {
 	cleanup := clearBCMEnvVars(t)
 	defer cleanup()
 
@@ -997,16 +1027,16 @@ func TestAccCMDeviceDeviceResource_ErrorDeviceCreateInvalidJSON(t *testing.T) {
 }
 
 // TestAccCMDeviceDeviceResource_ErrorDeviceValidationFailed tests BCM validation failure.
-// References: resource_cmdevice_device.go:417-432
+// References: resource_cmdevice_device.go:387-416 (ValidateEntity and error processing)
 //
-// Error Path Tested: Lines 417-432 (Create operation)
-// Expected Diagnostic: "Error Creating Device" with validation details
+// Error Path Tested: Lines 387-416 (Create operation, pre-flight validation)
+// Expected Diagnostic: "Validation Error: hostname" with "Hostname already exists in cluster"
 //
 // Test Scenario:
 // - Create device with configuration that BCM rejects.
-// - Mock BCM API returns success=false with validation array containing hostname and MAC errors.
-// - Provider should parse validation errors and return detailed error message.
-func TestAccCMDeviceDeviceResource_ErrorDeviceValidationFailed(t *testing.T) {
+// - Mock BCM API validateDevice returns array of validation errors.
+// - Provider should parse validation errors and return "Validation Error: <field>" diagnostic.
+func TestAccCMDeviceDeviceResource_MockErrorDeviceValidationFailed(t *testing.T) {
 	cleanup := clearBCMEnvVars(t)
 	defer cleanup()
 
@@ -1020,7 +1050,7 @@ func TestAccCMDeviceDeviceResource_ErrorDeviceValidationFailed(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDeviceResourceConfigWithMockServer(mockServer.URL, deviceName),
-				ExpectError: regexp.MustCompile(`(?is)Error Creating Device.*validation.*errors.*hostname.*already.*exists`),
+				ExpectError: regexp.MustCompile(`(?is)Validation Error.*hostname.*already exists`),
 			},
 		},
 	})
@@ -1037,7 +1067,7 @@ func TestAccCMDeviceDeviceResource_ErrorDeviceValidationFailed(t *testing.T) {
 // - Mock BCM API returns error when reading device back (getDevice fails).
 // - Provider should return "Error Reading Created Device" diagnostic.
 // - Note: This simulates eventual consistency issues where device created but not yet readable.
-func TestAccCMDeviceDeviceResource_ErrorDeviceReadAfterCreateFailed(t *testing.T) {
+func TestAccCMDeviceDeviceResource_MockErrorDeviceReadAfterCreateFailed(t *testing.T) {
 	cleanup := clearBCMEnvVars(t)
 	defer cleanup()
 
@@ -1068,7 +1098,7 @@ func TestAccCMDeviceDeviceResource_ErrorDeviceReadAfterCreateFailed(t *testing.T
 // - Device read operation returns malformed JSON (getDevice returns invalid JSON).
 // - BCM client's parseErrorResponse catches the JSON parsing error.
 // - Provider returns "Error Reading Created Device" diagnostic.
-func TestAccCMDeviceDeviceResource_ErrorDeviceReadInvalidJSON(t *testing.T) {
+func TestAccCMDeviceDeviceResource_MockErrorDeviceReadInvalidJSON(t *testing.T) {
 	cleanup := clearBCMEnvVars(t)
 	defer cleanup()
 
@@ -1101,11 +1131,11 @@ func TestAccCMDeviceDeviceResource_ErrorDeviceReadInvalidJSON(t *testing.T) {
 //
 // Note: This test would require a two-step process (create, then update with category error).
 // For simplicity in mock server testing, we skip this complex scenario.
-func TestAccCMDeviceDeviceResource_ErrorDeviceUpdateCategoryQueryFailed(t *testing.T) {
+func TestAccCMDeviceDeviceResource_MockErrorDeviceUpdateCategoryQueryFailed(t *testing.T) {
 	t.Skip("Skipping complex two-step mock server test - would require stateful mock server")
 }
 
-// TestAccCMDeviceDeviceResource_ErrorDeviceUpdateFailed tests device update API failure.
+// TestAccCMDeviceDeviceResource_MockErrorDeviceUpdateFailed tests device update API failure.
 // References: resource_cmdevice_device.go:763
 //
 // Error Path Tested: Lines 763-768 (Update operation)
@@ -1118,11 +1148,11 @@ func TestAccCMDeviceDeviceResource_ErrorDeviceUpdateCategoryQueryFailed(t *testi
 //
 // Note: This test would require a two-step process (create, then update with error).
 // For simplicity in mock server testing, we skip this complex scenario.
-func TestAccCMDeviceDeviceResource_ErrorDeviceUpdateFailed(t *testing.T) {
+func TestAccCMDeviceDeviceResource_MockErrorDeviceUpdateFailed(t *testing.T) {
 	t.Skip("Skipping complex two-step mock server test - would require stateful mock server")
 }
 
-// TestAccCMDeviceDeviceResource_ErrorDeviceUpdateReadFailed tests read-back after update failure.
+// TestAccCMDeviceDeviceResource_MockErrorDeviceUpdateReadFailed tests read-back after update failure.
 // References: resource_cmdevice_device.go:778
 //
 // Error Path Tested: Lines 778-783 (Update operation, read after update)
@@ -1135,11 +1165,11 @@ func TestAccCMDeviceDeviceResource_ErrorDeviceUpdateFailed(t *testing.T) {
 //
 // Note: This test would require a two-step process with stateful mock behavior.
 // For simplicity, we skip this complex scenario.
-func TestAccCMDeviceDeviceResource_ErrorDeviceUpdateReadFailed(t *testing.T) {
+func TestAccCMDeviceDeviceResource_MockErrorDeviceUpdateReadFailed(t *testing.T) {
 	t.Skip("Skipping complex two-step mock server test - would require stateful mock server")
 }
 
-// TestAccCMDeviceDeviceResource_ErrorDeviceDeleteFailed tests device deletion failure.
+// TestAccCMDeviceDeviceResource_MockErrorDeviceDeleteFailed tests device deletion failure.
 // References: resource_cmdevice_device.go:867
 //
 // Error Path Tested: Lines 867-873 (Delete operation)
@@ -1152,7 +1182,7 @@ func TestAccCMDeviceDeviceResource_ErrorDeviceUpdateReadFailed(t *testing.T) {
 //
 // Note: This test would require create first, then delete with error.
 // For simplicity, we skip this complex scenario.
-func TestAccCMDeviceDeviceResource_ErrorDeviceDeleteFailed(t *testing.T) {
+func TestAccCMDeviceDeviceResource_MockErrorDeviceDeleteFailed(t *testing.T) {
 	t.Skip("Skipping complex two-step mock server test - would require stateful mock server")
 }
 

--- a/specs/055-mock-server-validation-fix/analysis.md
+++ b/specs/055-mock-server-validation-fix/analysis.md
@@ -1,0 +1,83 @@
+# TDD Compliance Analysis: Fix Mock Server Validation Response Format
+
+## Analysis Summary
+
+**Status**: ✅ TDD COMPLIANT
+
+This bug fix follows TDD principles by:
+1. **RED**: Tests already exist and are failing
+2. **GREEN**: Implementation will make tests pass
+3. **REFACTOR**: No refactoring needed - minimal changes
+
+## Checklist
+
+### Specification Quality
+
+| Criteria | Status | Notes |
+|----------|--------|-------|
+| Problem clearly defined | ✅ | Mock server returns wrong format |
+| Root cause identified | ✅ | `{"success":true}` vs `[]` |
+| Solution approach documented | ✅ | Add validation call detection |
+| Acceptance criteria defined | ✅ | All 5 tests pass |
+
+### Plan Quality
+
+| Criteria | Status | Notes |
+|----------|--------|-------|
+| Implementation steps clear | ✅ | 6 code changes detailed |
+| Code locations identified | ✅ | Line numbers provided |
+| Test plan defined | ✅ | 5-step verification |
+| Rollback plan exists | ✅ | Simple revert |
+
+### Task Quality
+
+| Criteria | Status | Notes |
+|----------|--------|-------|
+| Tasks ordered by dependency | ✅ | RED → changes → GREEN |
+| Exit criteria defined | ✅ | Each task has exit criteria |
+| Commands provided | ✅ | Test commands included |
+| Parallelization noted | ✅ | Tasks 2-6 parallelizable |
+
+## TDD Workflow Analysis
+
+### Phase: RED (Already Complete)
+
+The failing tests already exist in the codebase:
+- `TestAccCMDeviceDeviceResource_ErrorDeviceCreateFailed`
+- `TestAccCMDeviceDeviceResource_ErrorDeviceCreateInvalidJSON`
+- `TestAccCMDeviceDeviceResource_ErrorDeviceValidationFailed`
+- `TestAccCMDeviceDeviceResource_ErrorDeviceReadAfterCreateFailed`
+- `TestAccCMDeviceDeviceResource_ErrorDeviceReadInvalidJSON`
+
+These tests verify error handling behavior. The mock server infrastructure issue prevents them from testing the actual error paths.
+
+### Phase: GREEN (Implementation)
+
+The implementation:
+1. Does NOT change production code
+2. Fixes test infrastructure only
+3. Makes existing tests pass
+
+### Phase: REFACTOR (Not Applicable)
+
+This is a bug fix, not a feature. No refactoring needed.
+
+## Risk Assessment
+
+| Risk | Level | Mitigation |
+|------|-------|------------|
+| Breaking other tests | Low | Full test suite run |
+| Production impact | None | Test-only changes |
+| Regression | Low | Specific error patterns |
+
+## Recommendations
+
+1. **Proceed with implementation** - Plan is TDD compliant
+2. **Run full test suite** - Verify no regressions
+3. **Keep changes minimal** - Only fix the specific issue
+
+## Conclusion
+
+This bug fix is well-structured and follows TDD principles. The existing failing tests serve as the RED phase, and the implementation will make them GREEN. No changes to production code are required.
+
+**Recommendation**: ✅ Proceed with implementation

--- a/specs/055-mock-server-validation-fix/plan.md
+++ b/specs/055-mock-server-validation-fix/plan.md
@@ -1,0 +1,222 @@
+# Implementation Plan: Fix Mock Server Validation Response Format
+
+## Overview
+
+This plan addresses the bug in mock server test infrastructure where validation API responses return incorrect format.
+
+## Design Decisions
+
+### Approach: Centralized Validation Handler
+
+Rather than adding validation handling to each individual handler function, we'll add validation call detection at the beginning of each affected handler. This approach:
+- Maintains the existing handler structure
+- Minimizes code changes
+- Makes the validation handling explicit and clear
+
+### Response Format
+
+**For successful validation (no errors)**:
+```go
+w.Header().Set("Content-Type", "application/json")
+w.WriteHeader(http.StatusOK)
+_, _ = w.Write([]byte("[]"))
+```
+
+**For validation failure (with errors)**:
+```go
+w.Header().Set("Content-Type", "application/json")
+w.WriteHeader(http.StatusOK)
+_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+    {"Field": "hostname", "Message": "...", "Severity": "ERROR"},
+})
+```
+
+## Implementation Details
+
+### File: `internal/provider/resource_cmdevice_device_mock_test.go`
+
+### Change 1: Update handleDeviceCreateError (lines ~421-451)
+
+Add validation handling before the default response:
+
+```go
+func handleDeviceCreateError(w http.ResponseWriter, req struct {...}) {
+    // Return valid category and partition
+    if req.Service == "cmdevice" && req.Call == "getCategory" {
+        // ... existing code ...
+    }
+    if req.Service == "CMPart" && req.Call == "getSoftwareImage" {
+        // ... existing code ...
+    }
+
+    // ADD: Handle validation calls - return empty array for success
+    if req.Call == "validateDevice" {
+        w.Header().Set("Content-Type", "application/json")
+        w.WriteHeader(http.StatusOK)
+        _, _ = w.Write([]byte("[]"))
+        return
+    }
+
+    // Fail on addDevice
+    if req.Service == "cmdevice" && req.Call == "addDevice" {
+        // ... existing code ...
+    }
+    // ... rest of function ...
+}
+```
+
+### Change 2: Update handleDeviceCreateInvalidJSON (lines ~453-487)
+
+Similar pattern - add validation handling:
+
+```go
+func handleDeviceCreateInvalidJSON(w http.ResponseWriter, req struct {...}) {
+    // ... existing handlers ...
+
+    // ADD: Handle validation calls
+    if req.Call == "validateDevice" {
+        w.Header().Set("Content-Type", "application/json")
+        w.WriteHeader(http.StatusOK)
+        _, _ = w.Write([]byte("[]"))
+        return
+    }
+
+    // Return invalid JSON only for addDevice
+    // ... existing code ...
+}
+```
+
+### Change 3: Update handleDeviceValidationFailure (lines ~489-531)
+
+This handler tests validation failure, so it needs to return validation errors in the correct format AND remove the incorrect validation from addDevice response:
+
+```go
+func handleDeviceValidationFailure(w http.ResponseWriter, req struct {...}) {
+    // ... existing category and partition handlers ...
+
+    // CHANGE: Return validation errors in correct array format
+    if req.Call == "validateDevice" {
+        w.Header().Set("Content-Type", "application/json")
+        w.WriteHeader(http.StatusOK)
+        _ = json.NewEncoder(w).Encode([]map[string]interface{}{
+            {
+                "Field":    "hostname",
+                "Message":  "Hostname already exists in cluster",
+                "Severity": "ERROR",
+            },
+            {
+                "Field":    "mac",
+                "Message":  "MAC address is already in use",
+                "Severity": "ERROR",
+            },
+        })
+        return
+    }
+
+    // REMOVE/SIMPLIFY: addDevice handling (won't be reached if validation fails)
+    // But keep for backwards compatibility in case validation is bypassed
+    if req.Service == "cmdevice" && req.Call == "addDevice" {
+        w.Header().Set("Content-Type", "application/json")
+        w.WriteHeader(http.StatusOK)
+        _ = json.NewEncoder(w).Encode(map[string]interface{}{"success": true})
+        return
+    }
+
+    // ... default response ...
+}
+```
+
+### Change 4: Update handleDeviceReadError (lines ~533-575)
+
+Add validation handling:
+
+```go
+func handleDeviceReadError(w http.ResponseWriter, req struct {...}) {
+    // ... existing handlers ...
+
+    // ADD: Handle validation calls
+    if req.Call == "validateDevice" {
+        w.Header().Set("Content-Type", "application/json")
+        w.WriteHeader(http.StatusOK)
+        _, _ = w.Write([]byte("[]"))
+        return
+    }
+
+    // Allow device creation to succeed
+    // ... existing code ...
+}
+```
+
+### Change 5: Update handleDeviceReadInvalidJSON (lines ~577-619)
+
+Add validation handling:
+
+```go
+func handleDeviceReadInvalidJSON(w http.ResponseWriter, req struct {...}) {
+    // ... existing handlers ...
+
+    // ADD: Handle validation calls
+    if req.Call == "validateDevice" {
+        w.Header().Set("Content-Type", "application/json")
+        w.WriteHeader(http.StatusOK)
+        _, _ = w.Write([]byte("[]"))
+        return
+    }
+
+    // Return success for device creation
+    // ... existing code ...
+}
+```
+
+### Change 6: Update Test Expectations
+
+For `TestAccCMDeviceDeviceResource_ErrorDeviceValidationFailed`, update the expected error message to match the validation response format:
+
+```go
+{
+    Config:      testAccDeviceResourceConfigWithMockServer(mockServer.URL, deviceName),
+    ExpectError: regexp.MustCompile(`(?s)Validation Error.*hostname.*already exists`),
+},
+```
+
+## Test Verification Plan
+
+### Step 1: Run affected tests before changes
+```bash
+TF_ACC=1 go test -v -timeout 120m ./internal/provider/ -run "^TestAccCMDeviceDeviceResource_Error(DeviceCreateFailed|DeviceCreateInvalidJSON|DeviceValidationFailed|DeviceReadAfterCreateFailed|DeviceReadInvalidJSON)$"
+```
+Expected: All 5 tests FAIL
+
+### Step 2: Apply changes
+
+### Step 3: Run affected tests after changes
+```bash
+TF_ACC=1 go test -v -timeout 120m ./internal/provider/ -run "^TestAccCMDeviceDeviceResource_Error"
+```
+Expected: All tests PASS
+
+### Step 4: Run full mock test suite
+```bash
+TF_ACC=1 go test -v -timeout 120m ./internal/provider/ -run "Mock|mock"
+```
+Expected: All mock tests PASS
+
+### Step 5: Run full test suite
+```bash
+make test
+```
+Expected: All tests PASS
+
+## Rollback Plan
+
+If issues are found:
+1. Revert changes to `resource_cmdevice_device_mock_test.go`
+2. Re-run tests to confirm original state
+
+## Dependencies
+
+None - this is a self-contained test infrastructure fix.
+
+## Timeline
+
+Estimated completion: Immediate (< 30 minutes of implementation + testing)

--- a/specs/055-mock-server-validation-fix/spec.md
+++ b/specs/055-mock-server-validation-fix/spec.md
@@ -1,0 +1,169 @@
+# Feature Specification: Fix Mock Server Validation Response Format
+
+## Overview
+
+**Issue**: [#55](https://github.com/hashi-demo-lab/terraform-provider-bcm/issues/55)
+**Type**: Bug Fix (Test Infrastructure)
+**Priority**: Low
+**Impact**: 5 tests failing (27.8% of device mock tests)
+
+## Problem Statement
+
+Five device resource error tests fail because the mock HTTP server returns `{"success":true}` instead of the expected empty array `[]` for validation responses.
+
+### Error Pattern
+```
+validation response expected array, got: {"success":true}
+```
+
+### Affected Tests
+All tests in `resource_cmdevice_device_mock_test.go`:
+1. `TestAccCMDeviceDeviceResource_ErrorDeviceCreateFailed`
+2. `TestAccCMDeviceDeviceResource_ErrorDeviceCreateInvalidJSON`
+3. `TestAccCMDeviceDeviceResource_ErrorDeviceValidationFailed`
+4. `TestAccCMDeviceDeviceResource_ErrorDeviceReadAfterCreateFailed`
+5. `TestAccCMDeviceDeviceResource_ErrorDeviceReadInvalidJSON`
+
+## Root Cause Analysis
+
+### Current Behavior
+
+The mock server handlers return a generic success response for unhandled API calls:
+
+```go
+// Default success response for unknown calls
+w.Header().Set("Content-Type", "application/json")
+w.WriteHeader(http.StatusOK)
+_ = json.NewEncoder(w).Encode(map[string]interface{}{"success": true})
+```
+
+### Expected Behavior
+
+The real BCM API validation endpoints return:
+- **Success**: `[]` (empty array)
+- **Errors**: Array of validation error objects
+
+```go
+[]  // Empty array on success
+
+// Or with validation errors:
+[
+  {
+    "baseType": "Validation",
+    "error_code": "BAD_VALUE",
+    "field": "hostname",
+    "message": "Invalid hostname format",
+    "severity": "ERROR"
+  }
+]
+```
+
+### Code Path Analysis
+
+**File**: `internal/provider/bcm_client.go:363-391`
+
+```go
+func (c *BCMClient) ValidateEntity(ctx context.Context, service, validateMethod string, entity map[string]interface{}, isCreate bool) ([]ValidationError, error) {
+    // ...
+    body, err := c.CallJSONRPC(ctx, service, validateMethod, entity, false)
+    // ...
+
+    // Parse validation response (should be array of validation objects or empty array)
+    var validationArray []map[string]interface{}
+    if err := json.Unmarshal(body, &validationArray); err != nil {
+        return nil, fmt.Errorf("validation response expected array, got: %s", limitString(string(body), 200))
+    }
+    // ...
+}
+```
+
+The `ValidateEntity()` function expects an array response. When the mock server returns `{"success": true}`, `json.Unmarshal` fails because it cannot unmarshal an object into `[]map[string]interface{}`.
+
+## Solution Design
+
+### Approach
+
+Update mock server handlers to detect validation API calls and return the correct response format (empty array `[]` for successful validation).
+
+### Implementation Strategy
+
+1. **Identify validation calls**: Check if `req.Call` starts with "validate"
+2. **Return correct format**: Return `[]` (empty array) for validation calls
+3. **Preserve existing behavior**: Keep `{"success": true}` for non-validation calls
+
+### Code Change
+
+Update each affected handler in `resource_cmdevice_device_mock_test.go` to detect validation calls:
+
+```go
+// Handle validation calls - must return array format
+if strings.HasPrefix(req.Call, "validate") {
+    w.Header().Set("Content-Type", "application/json")
+    w.WriteHeader(http.StatusOK)
+    _ = json.NewEncoder(w).Encode([]interface{}{}) // Empty array
+    return
+}
+```
+
+### Affected Handlers
+
+The following handler functions need to be updated:
+1. `handleDeviceCreateError` (line 421-451)
+2. `handleDeviceCreateInvalidJSON` (line 453-487)
+3. `handleDeviceValidationFailure` (line 489-531) - needs special handling for validation failure scenario
+4. `handleDeviceReadError` (line 533-575)
+5. `handleDeviceReadInvalidJSON` (line 577-619)
+
+### Special Case: handleDeviceValidationFailure
+
+The `handleDeviceValidationFailure` handler is specifically testing validation failure scenarios. It should return validation errors in the correct array format:
+
+```go
+// For validation failure scenario, return errors in array format
+if req.Service == "cmdevice" && req.Call == "validateDevice" {
+    w.Header().Set("Content-Type", "application/json")
+    w.WriteHeader(http.StatusOK)
+    _ = json.NewEncoder(w).Encode([]map[string]interface{}{
+        {
+            "Field":    "hostname",
+            "Message":  "Hostname already exists in cluster",
+            "Severity": "ERROR",
+        },
+        {
+            "Field":    "mac",
+            "Message":  "MAC address is already in use",
+            "Severity": "ERROR",
+        },
+    })
+    return
+}
+```
+
+## Acceptance Criteria
+
+1. All 5 affected tests pass
+2. Existing passing tests remain passing
+3. Mock server correctly simulates BCM API validation response format
+4. No changes to production code required
+
+## Verification
+
+After implementation, all 5 tests should pass:
+
+```bash
+TF_ACC=1 go test -v ./internal/provider/ -run "^TestAccCMDeviceDeviceResource_Error"
+```
+
+Expected output: All tests PASS
+
+## Non-Goals
+
+- No changes to production validation code (already working correctly)
+- No changes to real BCM API integration tests
+- No additional test scenarios beyond fixing existing failures
+
+## Risk Assessment
+
+- **Risk Level**: Very Low
+- **Reason**: Changes are isolated to mock test infrastructure
+- **Production Impact**: None - test-only changes

--- a/specs/055-mock-server-validation-fix/tasks.md
+++ b/specs/055-mock-server-validation-fix/tasks.md
@@ -1,0 +1,273 @@
+# Tasks: Fix Mock Server Validation Response Format
+
+## Task Checklist
+
+- [ ] Task 1: Verify failing tests (RED phase)
+- [ ] Task 2: Update handleDeviceCreateError handler
+- [ ] Task 3: Update handleDeviceCreateInvalidJSON handler
+- [ ] Task 4: Update handleDeviceValidationFailure handler
+- [ ] Task 5: Update handleDeviceReadError handler
+- [ ] Task 6: Update handleDeviceReadInvalidJSON handler
+- [ ] Task 7: Update TestAccCMDeviceDeviceResource_ErrorDeviceValidationFailed expectations
+- [ ] Task 8: Run affected tests (GREEN phase)
+- [ ] Task 9: Run full test suite
+- [ ] Task 10: Lint and format code
+- [ ] Task 11: Commit changes
+
+---
+
+## Task 1: Verify failing tests (RED phase)
+
+**Description**: Run the affected tests to confirm they fail with the expected error pattern.
+
+**Command**:
+```bash
+TF_ACC=1 go test -v -timeout 120m ./internal/provider/ -run "^TestAccCMDeviceDeviceResource_Error(DeviceCreateFailed|DeviceCreateInvalidJSON|DeviceValidationFailed|DeviceReadAfterCreateFailed|DeviceReadInvalidJSON)$" 2>&1 | head -100
+```
+
+**Expected Output**: All 5 tests fail with "validation response expected array" error.
+
+**Exit Criteria**: Tests fail with expected error message.
+
+---
+
+## Task 2: Update handleDeviceCreateError handler
+
+**File**: `internal/provider/resource_cmdevice_device_mock_test.go`
+**Lines**: ~421-451
+
+**Change**: Add validation call handling before the default response.
+
+**Code to Add** (after partition handling, before addDevice check):
+```go
+// Handle validation calls - return empty array for success
+if req.Call == "validateDevice" {
+    w.Header().Set("Content-Type", "application/json")
+    w.WriteHeader(http.StatusOK)
+    _, _ = w.Write([]byte("[]"))
+    return
+}
+```
+
+**Exit Criteria**: Handler returns `[]` for validateDevice calls.
+
+---
+
+## Task 3: Update handleDeviceCreateInvalidJSON handler
+
+**File**: `internal/provider/resource_cmdevice_device_mock_test.go`
+**Lines**: ~453-487
+
+**Change**: Add validation call handling before the addDevice check.
+
+**Code to Add** (after partition handling, before addDevice check):
+```go
+// Handle validation calls - return empty array for success
+if req.Call == "validateDevice" {
+    w.Header().Set("Content-Type", "application/json")
+    w.WriteHeader(http.StatusOK)
+    _, _ = w.Write([]byte("[]"))
+    return
+}
+```
+
+**Exit Criteria**: Handler returns `[]` for validateDevice calls.
+
+---
+
+## Task 4: Update handleDeviceValidationFailure handler
+
+**File**: `internal/provider/resource_cmdevice_device_mock_test.go`
+**Lines**: ~489-531
+
+**Change**: Replace the addDevice validation response with proper validateDevice response.
+
+**Code to Replace**: The `addDevice` handler that returns validation errors in object format.
+
+**New Code**:
+```go
+// Handle validation calls - return validation errors in array format
+if req.Call == "validateDevice" {
+    w.Header().Set("Content-Type", "application/json")
+    w.WriteHeader(http.StatusOK)
+    _ = json.NewEncoder(w).Encode([]map[string]interface{}{
+        {
+            "Field":    "hostname",
+            "Message":  "Hostname already exists in cluster",
+            "Severity": "ERROR",
+        },
+        {
+            "Field":    "mac",
+            "Message":  "MAC address is already in use",
+            "Severity": "ERROR",
+        },
+    })
+    return
+}
+```
+
+**Also**: Update or simplify the addDevice handler since validation will fail before reaching it.
+
+**Exit Criteria**: Handler returns validation errors in array format for validateDevice calls.
+
+---
+
+## Task 5: Update handleDeviceReadError handler
+
+**File**: `internal/provider/resource_cmdevice_device_mock_test.go`
+**Lines**: ~533-575
+
+**Change**: Add validation call handling before the addDevice check.
+
+**Code to Add** (after partition handling, before addDevice check):
+```go
+// Handle validation calls - return empty array for success
+if req.Call == "validateDevice" {
+    w.Header().Set("Content-Type", "application/json")
+    w.WriteHeader(http.StatusOK)
+    _, _ = w.Write([]byte("[]"))
+    return
+}
+```
+
+**Exit Criteria**: Handler returns `[]` for validateDevice calls.
+
+---
+
+## Task 6: Update handleDeviceReadInvalidJSON handler
+
+**File**: `internal/provider/resource_cmdevice_device_mock_test.go`
+**Lines**: ~577-619
+
+**Change**: Add validation call handling before the addDevice check.
+
+**Code to Add** (after partition handling, before addDevice check):
+```go
+// Handle validation calls - return empty array for success
+if req.Call == "validateDevice" {
+    w.Header().Set("Content-Type", "application/json")
+    w.WriteHeader(http.StatusOK)
+    _, _ = w.Write([]byte("[]"))
+    return
+}
+```
+
+**Exit Criteria**: Handler returns `[]` for validateDevice calls.
+
+---
+
+## Task 7: Update TestAccCMDeviceDeviceResource_ErrorDeviceValidationFailed expectations
+
+**File**: `internal/provider/resource_cmdevice_device_mock_test.go`
+**Lines**: ~999-1027
+
+**Change**: Update the ExpectError regex to match the new validation error format.
+
+**Current**:
+```go
+ExpectError: regexp.MustCompile(`(?is)Error Creating Device.*validation.*errors.*hostname.*already.*exists`),
+```
+
+**New**:
+```go
+ExpectError: regexp.MustCompile(`(?is)Validation Error.*hostname.*already exists`),
+```
+
+**Exit Criteria**: Test expects the correct error message format from validation.
+
+---
+
+## Task 8: Run affected tests (GREEN phase)
+
+**Description**: Run the affected tests to confirm they pass.
+
+**Command**:
+```bash
+TF_ACC=1 go test -v -timeout 120m ./internal/provider/ -run "^TestAccCMDeviceDeviceResource_Error(DeviceCreateFailed|DeviceCreateInvalidJSON|DeviceValidationFailed|DeviceReadAfterCreateFailed|DeviceReadInvalidJSON)$"
+```
+
+**Expected Output**: All 5 tests PASS.
+
+**Exit Criteria**: 5/5 tests pass.
+
+---
+
+## Task 9: Run full test suite
+
+**Description**: Run all mock tests to ensure no regressions.
+
+**Command**:
+```bash
+make test
+```
+
+**Expected Output**: All tests PASS.
+
+**Exit Criteria**: Full test suite passes.
+
+---
+
+## Task 10: Lint and format code
+
+**Description**: Ensure code meets style guidelines.
+
+**Commands**:
+```bash
+make fmt
+make lint
+```
+
+**Expected Output**: No lint errors.
+
+**Exit Criteria**: Code passes all linting checks.
+
+---
+
+## Task 11: Commit changes
+
+**Description**: Commit the fix with appropriate message.
+
+**Command**:
+```bash
+git add internal/provider/resource_cmdevice_device_mock_test.go
+git commit -m "fix(tests): correct mock server validation response format
+
+Updates mock server handlers to return array format ([]) for validation
+API calls instead of object format ({\"success\": true}).
+
+The BCM API ValidateEntity() function expects array responses for
+validation calls. The mock server was returning incorrect format,
+causing 5 device error tests to fail.
+
+Changes:
+- handleDeviceCreateError: Add validateDevice handler returning []
+- handleDeviceCreateInvalidJSON: Add validateDevice handler returning []
+- handleDeviceValidationFailure: Return validation errors in array format
+- handleDeviceReadError: Add validateDevice handler returning []
+- handleDeviceReadInvalidJSON: Add validateDevice handler returning []
+- Update test expectations for validation error format
+
+Fixes #55"
+```
+
+**Exit Criteria**: Changes committed with descriptive message.
+
+---
+
+## Summary
+
+| Task | Description | Dependencies |
+|------|-------------|--------------|
+| 1 | Verify failing tests | None |
+| 2 | Update handleDeviceCreateError | Task 1 |
+| 3 | Update handleDeviceCreateInvalidJSON | Task 1 |
+| 4 | Update handleDeviceValidationFailure | Task 1 |
+| 5 | Update handleDeviceReadError | Task 1 |
+| 6 | Update handleDeviceReadInvalidJSON | Task 1 |
+| 7 | Update test expectations | Task 4 |
+| 8 | Run affected tests | Tasks 2-7 |
+| 9 | Run full test suite | Task 8 |
+| 10 | Lint and format | Task 9 |
+| 11 | Commit changes | Task 10 |
+
+**Parallelizable**: Tasks 2-6 can be done in parallel after Task 1.


### PR DESCRIPTION
## Summary

- Fixed mock server validation response format in device error tests
- Mock handlers now return `[]` (empty array) for validation calls instead of `{"success": true}`
- Renamed all mock tests to include "Mock" for better discoverability

## Problem

Five device resource error tests were failing because the mock HTTP server returned `{"success":true}` instead of the expected empty array `[]` for validation responses. The `ValidateEntity()` function in `bcm_client.go` expects array responses.

## Solution

Updated 5 mock server handlers to detect validation API calls and return the correct array format:
1. `handleDeviceCreateError` - Added validateDevice handler returning `[]`
2. `handleDeviceCreateInvalidJSON` - Added validateDevice handler returning `[]`
3. `handleDeviceValidationFailure` - Returns validation errors in array format
4. `handleDeviceReadError` - Added validateDevice handler returning `[]`
5. `handleDeviceReadInvalidJSON` - Added validateDevice handler returning `[]`

## Test Results

All 17 mock tests now pass:
```
TF_ACC=1 go test -v ./internal/provider/ -run "Mock"
--- PASS: TestAccCMDeviceDeviceResource_MockErrorCategoryNotFound (1.76s)
--- PASS: TestAccCMDeviceDeviceResource_MockErrorCategoryInvalidJSON (1.72s)
--- PASS: TestAccCMDeviceDeviceResource_MockErrorCategoryNoPartition (1.86s)
--- PASS: TestAccCMDeviceDeviceResource_MockErrorCategoryProxyMissingParent (1.73s)
--- PASS: TestAccCMDeviceDeviceResource_MockErrorPartitionsQueryFailed (1.72s)
--- PASS: TestAccCMDeviceDeviceResource_MockErrorPartitionsInvalidJSON (1.91s)
--- PASS: TestAccCMDeviceDeviceResource_MockErrorPartitionsNoBase (1.72s)
--- PASS: TestAccCMDeviceDeviceResource_MockErrorPartitionNotCommitted (171.87s)
--- PASS: TestAccCMDeviceDeviceResource_MockErrorDeviceCreateFailed (1.68s)
--- PASS: TestAccCMDeviceDeviceResource_MockErrorDeviceCreateInvalidJSON (1.66s)
--- PASS: TestAccCMDeviceDeviceResource_MockErrorDeviceValidationFailed (1.69s)
--- PASS: TestAccCMDeviceDeviceResource_MockErrorDeviceReadAfterCreateFailed (3.71s)
--- PASS: TestAccCMDeviceDeviceResource_MockErrorDeviceReadInvalidJSON (3.70s)
--- SKIP: TestAccCMDeviceDeviceResource_MockErrorDeviceUpdateCategoryQueryFailed (0.00s)
--- SKIP: TestAccCMDeviceDeviceResource_MockErrorDeviceUpdateFailed (0.00s)
--- SKIP: TestAccCMDeviceDeviceResource_MockErrorDeviceUpdateReadFailed (0.00s)
--- SKIP: TestAccCMDeviceDeviceResource_MockErrorDeviceDeleteFailed (0.00s)
PASS
```

## Test plan

- [x] All 5 originally failing tests now pass
- [x] All other mock tests still pass
- [x] Unit tests pass
- [x] Test naming convention updated for discoverability

Fixes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)