### PR TITLE
fix(tests): Add retry backoffs to all CheckDestroy functions

### DIFF
--- a/internal/provider/resource_cmdevice_category_test.go
+++ b/internal/provider/resource_cmdevice_category_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -26,8 +27,11 @@ import (
 func testAccCheckCMDeviceCategoryDestroy(s *terraform.State) error {
 	// Create BCM client using shared helper
 	client := createTestBCMClient(&testing.T{})
+	ctx := context.Background()
 
 	resourcesChecked := 0
+	var errors []string
+
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "bcm_cmdevice_category" {
 			continue
@@ -37,28 +41,32 @@ func testAccCheckCMDeviceCategoryDestroy(s *terraform.State) error {
 		name := rs.Primary.Attributes["name"]
 		uuid := rs.Primary.Attributes["uuid"]
 
-		// Add 10s timeout context per API call
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
+		// Verify category deleted with exponential backoff (4 retries)
+		deleted := verifyResourceDeleted(
+			ctx,
+			client,
+			"cmdevice",
+			"getCategory",
+			name,
+			4, // retry count with exponential backoff
+		)
 
-		// Attempt to read the category
-		body, err := client.CallJSONRPC(ctx, "cmdevice", "getCategory", name)
-
-		// If no error and response contains data, resource still exists
-		if err == nil {
-			var categoryData map[string]interface{}
-			if json.Unmarshal(body, &categoryData) == nil && len(categoryData) > 0 {
-				return fmt.Errorf("category still exists after destroy: name=%s uuid=%s response=%s",
-					name, uuid, string(body))
-			}
+		if !deleted {
+			errors = append(errors, fmt.Sprintf(
+				"Category still exists after destroy. Name: %s, UUID: %s, Retries: 4",
+				name, uuid))
 		}
-		// If error or empty response, resource is gone (expected)
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("CheckDestroy failures:\n  - %s\n  - Verified: %d categories",
+			strings.Join(errors, "\n  - "),
+			resourcesChecked)
 	}
 
 	// Log number of resources checked for debugging
-	if resourcesChecked == 0 {
-		// This is not an error - may be checking destroy for data sources or other resources
-		return nil
+	if resourcesChecked > 0 {
+		fmt.Printf("[DEBUG] CheckDestroy verified %d category resources were deleted\n", resourcesChecked)
 	}
 
 	return nil

--- a/internal/provider/resource_cmdevice_device_test.go
+++ b/internal/provider/resource_cmdevice_device_test.go
@@ -107,6 +107,7 @@ func testAccCheckCMDeviceDeviceDestroy(s *terraform.State) error {
 	}
 
 	// Phase 2: Verify categories are deleted (must happen after devices)
+	// Uses retry with exponential backoff to handle eventual consistency
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "bcm_cmdevice_category" {
 			continue
@@ -116,23 +117,27 @@ func testAccCheckCMDeviceDeviceDestroy(s *terraform.State) error {
 		name := rs.Primary.Attributes["name"]
 		uuid := rs.Primary.Attributes["uuid"]
 
-		// Attempt to read the category
-		body, err := client.CallJSONRPC(ctx, "cmdevice", "getCategory", name)
+		// Verify category deleted with exponential backoff
+		deleted := verifyResourceDeleted(
+			ctx,
+			client,
+			"cmdevice",
+			"getCategory",
+			name,
+			4, // retry count with exponential backoff
+		)
 
-		// If no error and response contains data, resource still exists
-		if err == nil {
-			var categoryData map[string]interface{}
-			if json.Unmarshal(body, &categoryData) == nil && len(categoryData) > 0 {
-				errors = append(errors, fmt.Sprintf(
-					"Category still exists after destroy. Name: %s, UUID: %s",
-					name,
-					uuid,
-				))
-			}
+		if !deleted {
+			errors = append(errors, fmt.Sprintf(
+				"Category still exists after destroy. Name: %s, UUID: %s, Retries: 4",
+				name,
+				uuid,
+			))
 		}
 	}
 
 	// Phase 3: Verify software images are deleted (must happen last)
+	// Uses retry with exponential backoff to handle eventual consistency
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "bcm_cmpart_softwareimage" {
 			continue
@@ -144,19 +149,21 @@ func testAccCheckCMDeviceDeviceDestroy(s *terraform.State) error {
 			continue // Resource was never created
 		}
 
-		// Try to read the software image via BCM API
-		body, err := client.CallJSONRPC(ctx, "CMPart", "getSoftwareImage", uuid)
+		// Verify software image deleted with exponential backoff
+		deleted := verifyResourceDeleted(
+			ctx,
+			client,
+			"CMPart",
+			"getSoftwareImage",
+			uuid,
+			4, // retry count with exponential backoff
+		)
 
-		// If API returns error OR empty response, resource is deleted (success)
-		if err == nil {
-			// Try to unmarshal response
-			var imageData map[string]interface{}
-			if json.Unmarshal(body, &imageData) == nil && len(imageData) > 0 {
-				errors = append(errors, fmt.Sprintf(
-					"Software image still exists after destroy. UUID: %s",
-					uuid,
-				))
-			}
+		if !deleted {
+			errors = append(errors, fmt.Sprintf(
+				"Software image still exists after destroy. UUID: %s, Retries: 4",
+				uuid,
+			))
 		}
 	}
 

--- a/internal/provider/resource_cmnet_network_test.go
+++ b/internal/provider/resource_cmnet_network_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -322,8 +323,11 @@ func TestAccCMNetNetwork_DriftDetection(t *testing.T) {
 func testAccCheckCMNetNetworkDestroy(s *terraform.State) error {
 	// Create BCM client using shared helper
 	client := createTestBCMClient(&testing.T{})
+	ctx := context.Background()
 
 	resourcesChecked := 0
+	var errors []string
+
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "bcm_cmnet_network" {
 			continue
@@ -333,22 +337,32 @@ func testAccCheckCMNetNetworkDestroy(s *terraform.State) error {
 		name := rs.Primary.Attributes["name"]
 		uuid := rs.Primary.Attributes["uuid"]
 
-		// Add 10s timeout context per API call
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
+		// Verify network deleted with exponential backoff (4 retries)
+		deleted := verifyResourceDeleted(
+			ctx,
+			client,
+			"cmnet",
+			"getNetwork",
+			name,
+			4, // retry count with exponential backoff
+		)
 
-		// Attempt to read the network
-		body, err := client.CallJSONRPC(ctx, "cmnet", "getNetwork", name)
-
-		// If no error and response contains data, resource still exists
-		if err == nil {
-			var networkData map[string]interface{}
-			if json.Unmarshal(body, &networkData) == nil && len(networkData) > 0 {
-				return fmt.Errorf("network still exists after destroy: name=%s uuid=%s response=%s",
-					name, uuid, string(body))
-			}
+		if !deleted {
+			errors = append(errors, fmt.Sprintf(
+				"Network still exists after destroy. Name: %s, UUID: %s, Retries: 4",
+				name, uuid))
 		}
-		// If error or empty response, resource is gone (expected)
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("CheckDestroy failures:\n  - %s\n  - Verified: %d networks",
+			strings.Join(errors, "\n  - "),
+			resourcesChecked)
+	}
+
+	// Log number of resources checked for debugging
+	if resourcesChecked > 0 {
+		fmt.Printf("[DEBUG] CheckDestroy verified %d network resources were deleted\n", resourcesChecked)
 	}
 
 	return nil

--- a/internal/provider/resource_cmpart_softwareimage_test.go
+++ b/internal/provider/resource_cmpart_softwareimage_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -1130,20 +1131,11 @@ resource "bcm_cmpart_softwareimage" "test" {
 // Note: Software images may still exist if referenced by categories - this is not a test failure,
 // as the proper cleanup order is: devices → categories → software images.
 func testAccCheckCMPartSoftwareImageDestroy(s *terraform.State) error {
-	client, err := NewBCMClient(
-		context.Background(),
-		os.Getenv("BCM_ENDPOINT"),
-		os.Getenv("BCM_USERNAME"),
-		os.Getenv("BCM_PASSWORD"),
-		true, // insecure_skip_verify
-		30,   // timeout
-	)
-	if err != nil {
-		return fmt.Errorf("Failed to create BCM client for CheckDestroy: %v", err)
-	}
+	client := createTestBCMClient(&testing.T{})
+	ctx := context.Background()
 
 	resourceCount := 0
-	ctx := context.Background()
+	var errors []string
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "bcm_cmpart_softwareimage" {
@@ -1157,30 +1149,18 @@ func testAccCheckCMPartSoftwareImageDestroy(s *terraform.State) error {
 			continue // Resource was never created
 		}
 
-		// Create 10s timeout context for this API call
-		apiCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
+		// Verify software image deleted with exponential backoff (4 retries)
+		deleted := verifyResourceDeleted(
+			ctx,
+			client,
+			"CMPart",
+			"getSoftwareImage",
+			uuid,
+			4, // retry count with exponential backoff
+		)
 
-		// Try to read the software image via BCM API
-		body, err := client.CallJSONRPC(apiCtx, "CMPart", "getSoftwareImage", uuid)
-
-		// If API returns error OR empty response, resource is deleted (success)
-		if err != nil {
-			// API error means resource doesn't exist (deleted successfully)
-			continue
-		}
-
-		// Try to unmarshal response
-		var imageData map[string]interface{}
-		if err := json.Unmarshal(body, &imageData); err != nil {
-			// Can't parse response, assume deleted
-			continue
-		}
-
-		// If we got valid data back, resource still exists
-		// Check if it's referenced by categories before failing
-		if len(imageData) > 0 {
-			// Check for dependent categories
+		if !deleted {
+			// Image still exists - check if it's referenced by categories
 			result, checkErr := CheckCategoriesUsingImage(ctx, client, imageName)
 			if checkErr == nil && result.HasDependencies {
 				// Image still exists because it's referenced by categories
@@ -1191,9 +1171,16 @@ func testAccCheckCMPartSoftwareImageDestroy(s *terraform.State) error {
 			}
 
 			// Image exists but has no dependencies - this is a test failure
-			return fmt.Errorf("Software image '%s' still exists after destroy with no dependencies. UUID: %s, Response: %s",
-				imageName, uuid, string(body))
+			errors = append(errors, fmt.Sprintf(
+				"Software image '%s' still exists after destroy with no dependencies. UUID: %s, Retries: 4",
+				imageName, uuid))
 		}
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("CheckDestroy failures:\n  - %s\n  - Verified: %d software images",
+			strings.Join(errors, "\n  - "),
+			resourceCount)
 	}
 
 	// Log summary


### PR DESCRIPTION
## Summary
- Standardize all CheckDestroy functions to use `verifyResourceDeleted` helper with exponential backoff
- Adds 4 retries with exponential backoff (1s, 2s, 4s, 8s) to handle BCM API eventual consistency
- Improves test reliability by avoiding intermittent failures during resource cleanup verification

## Changes
- **resource_cmdevice_device_test.go**: Update phases 2 and 3 to use `verifyResourceDeleted` for categories and software images
- **resource_cmdevice_category_test.go**: Use `verifyResourceDeleted` instead of direct API call
- **resource_cmnet_network_test.go**: Use `verifyResourceDeleted` instead of direct API call
- **resource_cmpart_softwareimage_test.go**: Use `verifyResourceDeleted` and `createTestBCMClient` helper

## Benefits
- Consistent retry behavior across all resource types
- Better handling of BCM API eventual consistency
- Structured error messages with retry count for debugging
- Debug logging for resource cleanup summary

## Test Plan
- [x] Run `TestAccCMDeviceDevice_Idempotency` with `-count 5` - all pass
- [x] Run `TestAccCMDeviceCategoryResource_Basic` - passes
- [x] Run `TestAccCMPartSoftwareImageResource_Basic` - passes
- [x] Run `TestAccCMNetNetwork_Basic` - passes

Fixes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)