### PR TITLE
feat(cmdevice): require interfaces block for network configuration

### DIFF
--- a/docs/resources/cmdevice_device.md
+++ b/docs/resources/cmdevice_device.md
@@ -105,11 +105,14 @@ resource "bcm_cmdevice_device" "compute_ipmi" {
   notes = "IPMI-enabled compute node with power management"
 }
 
-# Example 4: GPU compute node with multiple network interfaces
+# Example 4: GPU compute node with multiple interfaces
+# Management NIC for provisioning, high-speed data NIC for GPU traffic,
+# and a BMC interface for out-of-band management.
 resource "bcm_cmdevice_device" "gpu_node" {
   hostname = "citest-gpu-node-01"
   category = bcm_cmdevice_category.compute.id
 
+  # Management interface - used for PXE boot and provisioning
   interfaces {
     name     = "eth0"
     type     = "physical"
@@ -119,12 +122,28 @@ resource "bcm_cmdevice_device" "gpu_node" {
     dhcp     = true
   }
 
-  # Power control
+  # High-speed data interface - for GPU-to-GPU and storage traffic
+  interfaces {
+    name = "eth1"
+    type = "physical"
+    mac  = "00:11:22:33:44:68"
+    dhcp = true
+  }
+
+  # BMC interface - out-of-band IPMI management
+  interfaces {
+    name = "ipmi"
+    type = "bmc"
+    ip   = "192.168.100.11"
+    dhcp = false
+  }
+
+  # Power control via IPMI (uses BMC interface)
   power_control = "ipmi"
 
   # Network configuration for high-performance networking
   default_gateway        = "192.168.1.1"
-  default_gateway_metric = 50 # Lower metric for preferred route
+  default_gateway_metric = 50
 
   # Boot configuration with GPU-specific parameters
   boot_loader       = "pxelinux"
@@ -134,14 +153,16 @@ resource "bcm_cmdevice_device" "gpu_node" {
   serial_number = "SN-GPU-001"
   part_number   = "PN-GPU-NODE-001"
 
-  notes = "GPU compute node with NVIDIA drivers and RDMA networking"
+  notes = "GPU compute node with management, data, and BMC interfaces"
 }
 
-# Example 5: Storage node with custom partition configuration
+# Example 5: Storage node with bonded interfaces
+# Uses a bond for redundancy on the storage network.
 resource "bcm_cmdevice_device" "storage_node" {
   hostname = "citest-storage-node-01"
   category = bcm_cmdevice_category.compute.id
 
+  # Management interface for provisioning
   interfaces {
     name     = "eth0"
     type     = "physical"
@@ -149,6 +170,28 @@ resource "bcm_cmdevice_device" "storage_node" {
     network  = data.bcm_cmnet_networks.all.networks[0].id
     bootable = true
     dhcp     = true
+  }
+
+  # Member interfaces for bond (no network assignment - managed by bond)
+  interfaces {
+    name = "eth1"
+    type = "physical"
+    mac  = "00:11:22:33:44:69"
+  }
+
+  interfaces {
+    name = "eth2"
+    type = "physical"
+    mac  = "00:11:22:33:44:79"
+  }
+
+  # Bonded interface for storage traffic (uses eth1 + eth2)
+  interfaces {
+    name      = "bond0"
+    type      = "bond"
+    dhcp      = true
+    members   = ["eth1", "eth2"]
+    bond_mode = "802.3ad"
   }
 
   # Power control
@@ -166,7 +209,7 @@ resource "bcm_cmdevice_device" "storage_node" {
   serial_number = "SN-STORAGE-001"
   part_number   = "PN-STORAGE-NODE-001"
 
-  notes = "Storage node for Ceph cluster"
+  notes = "Storage node with bonded interfaces for Ceph cluster"
 }
 
 # =============================================================================

--- a/docs/resources/cmdevice_device.md
+++ b/docs/resources/cmdevice_device.md
@@ -4,14 +4,14 @@ page_title: "bcm_cmdevice_device Resource - bcm"
 subcategory: ""
 description: |-
   Manages a BCM device (compute node) in the cluster.
-  Devices represent physical or virtual nodes that can be provisioned and managed by BCM. Each device requires a unique hostname, MAC address, category assignment, and management network configuration.
+  Devices represent physical or virtual nodes that can be provisioned and managed by BCM. Each device requires a unique hostname, category assignment, and at least one network interface.
 ---
 
 # bcm_cmdevice_device (Resource)
 
 Manages a BCM device (compute node) in the cluster.
 
-Devices represent physical or virtual nodes that can be provisioned and managed by BCM. Each device requires a unique hostname, MAC address, category assignment, and management network configuration.
+Devices represent physical or virtual nodes that can be provisioned and managed by BCM. Each device requires a unique hostname, category assignment, and at least one network interface.
 
 ## Example Usage
 
@@ -37,20 +37,34 @@ resource "bcm_cmpart_softwareimage" "ubuntu_compute" {
 
 # Example 1: Basic compute device with minimal configuration
 resource "bcm_cmdevice_device" "compute_basic" {
-  hostname           = "citest-compute-node-01"
-  mac                = "00:11:22:33:44:55"
-  category           = bcm_cmdevice_category.compute.id
-  management_network = data.bcm_cmnet_networks.all.networks[0].id
+  hostname = "citest-compute-node-01"
+  category = bcm_cmdevice_category.compute.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:55"
+    network  = data.bcm_cmnet_networks.all.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   notes = "Basic compute node managed by Terraform"
 }
 
 # Example 2: Compute device with custom kernel parameters and boot configuration
 resource "bcm_cmdevice_device" "compute_custom" {
-  hostname           = "citest-compute-node-02"
-  mac                = "00:11:22:33:44:56"
-  category           = bcm_cmdevice_category.compute.id
-  management_network = data.bcm_cmnet_networks.all.networks[0].id
+  hostname = "citest-compute-node-02"
+  category = bcm_cmdevice_category.compute.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:56"
+    network  = data.bcm_cmnet_networks.all.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   # Boot configuration
   boot_loader       = "pxelinux"
@@ -61,10 +75,17 @@ resource "bcm_cmdevice_device" "compute_custom" {
 
 # Example 3: IPMI-enabled device with power control and network configuration
 resource "bcm_cmdevice_device" "compute_ipmi" {
-  hostname           = "citest-compute-node-03"
-  mac                = "00:11:22:33:44:57"
-  category           = bcm_cmdevice_category.compute.id
-  management_network = data.bcm_cmnet_networks.all.networks[0].id
+  hostname = "citest-compute-node-03"
+  category = bcm_cmdevice_category.compute.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:57"
+    network  = data.bcm_cmnet_networks.all.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   # Power control via IPMI
   power_control = "ipmi"
@@ -86,10 +107,17 @@ resource "bcm_cmdevice_device" "compute_ipmi" {
 
 # Example 4: GPU compute node with multiple network interfaces
 resource "bcm_cmdevice_device" "gpu_node" {
-  hostname           = "citest-gpu-node-01"
-  mac                = "00:11:22:33:44:58"
-  category           = bcm_cmdevice_category.compute.id
-  management_network = data.bcm_cmnet_networks.all.networks[0].id
+  hostname = "citest-gpu-node-01"
+  category = bcm_cmdevice_category.compute.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:58"
+    network  = data.bcm_cmnet_networks.all.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   # Power control
   power_control = "ipmi"
@@ -111,10 +139,17 @@ resource "bcm_cmdevice_device" "gpu_node" {
 
 # Example 5: Storage node with custom partition configuration
 resource "bcm_cmdevice_device" "storage_node" {
-  hostname           = "citest-storage-node-01"
-  mac                = "00:11:22:33:44:59"
-  category           = bcm_cmdevice_category.compute.id
-  management_network = data.bcm_cmnet_networks.all.networks[0].id
+  hostname = "citest-storage-node-01"
+  category = bcm_cmdevice_category.compute.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:59"
+    network  = data.bcm_cmnet_networks.all.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   # Power control
   power_control = "ipmi"
@@ -165,10 +200,17 @@ resource "bcm_cmkube_cluster" "production" {
 # Example 6: Kubernetes control plane node with kubelet_role
 # This device runs the Kubernetes control plane components (API server, etc.)
 resource "bcm_cmdevice_device" "k8s_control_plane" {
-  hostname           = "citest-k8s-cp-01"
-  mac                = "00:11:22:33:44:60"
-  category           = bcm_cmdevice_category.compute.id
-  management_network = data.bcm_cmnet_networks.all.networks[0].id
+  hostname = "citest-k8s-cp-01"
+  category = bcm_cmdevice_category.compute.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:60"
+    network  = data.bcm_cmnet_networks.all.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   # Power control
   power_control = "ipmi"
@@ -190,10 +232,17 @@ resource "bcm_cmdevice_device" "k8s_control_plane" {
 # Example 7: Kubernetes worker node with kubelet_role
 # This device runs application workloads scheduled by Kubernetes
 resource "bcm_cmdevice_device" "k8s_worker" {
-  hostname           = "citest-k8s-worker-01"
-  mac                = "00:11:22:33:44:61"
-  category           = bcm_cmdevice_category.compute.id
-  management_network = data.bcm_cmnet_networks.all.networks[0].id
+  hostname = "citest-k8s-worker-01"
+  category = bcm_cmdevice_category.compute.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:61"
+    network  = data.bcm_cmnet_networks.all.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   # Power control
   power_control = "ipmi"
@@ -215,10 +264,17 @@ resource "bcm_cmdevice_device" "k8s_worker" {
 # Example 8: Etcd host node with etcd_host_role
 # This device hosts an etcd cluster member for distributed key-value storage
 resource "bcm_cmdevice_device" "etcd_host" {
-  hostname           = "citest-etcd-host-01"
-  mac                = "00:11:22:33:44:62"
-  category           = bcm_cmdevice_category.compute.id
-  management_network = data.bcm_cmnet_networks.all.networks[0].id
+  hostname = "citest-etcd-host-01"
+  category = bcm_cmdevice_category.compute.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:62"
+    network  = data.bcm_cmnet_networks.all.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   # Power control
   power_control = "ipmi"
@@ -238,10 +294,17 @@ resource "bcm_cmdevice_device" "etcd_host" {
 # Example 9: Combined control plane node with both roles
 # This device runs both etcd and Kubernetes control plane (common in small clusters)
 resource "bcm_cmdevice_device" "k8s_combined_cp" {
-  hostname           = "citest-k8s-combined-01"
-  mac                = "00:11:22:33:44:63"
-  category           = bcm_cmdevice_category.compute.id
-  management_network = data.bcm_cmnet_networks.all.networks[0].id
+  hostname = "citest-k8s-combined-01"
+  category = bcm_cmdevice_category.compute.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:63"
+    network  = data.bcm_cmnet_networks.all.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   # Power control
   power_control = "ipmi"
@@ -284,10 +347,17 @@ resource "bcm_cmdevice_device" "k8s_combined_cp" {
 # Import first: terraform import bcm_cmdevice_device.existing_cp <uuid>
 resource "bcm_cmdevice_device" "existing_cp" {
   # These values must match the existing device after import
-  hostname           = "existing-server-01"
-  category           = bcm_cmdevice_category.compute.id
-  management_network = data.bcm_cmnet_networks.all.networks[0].id
-  mac                = "00:11:22:33:44:70"
+  hostname = "existing-server-01"
+  category = bcm_cmdevice_category.compute.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:70"
+    network  = data.bcm_cmnet_networks.all.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   # Existing device settings are preserved
   power_control = "ipmi"
@@ -310,10 +380,17 @@ resource "bcm_cmdevice_device" "existing_cp" {
 # Example 11: Existing device converted to Kubernetes worker
 # Import first: terraform import bcm_cmdevice_device.existing_worker <uuid>
 resource "bcm_cmdevice_device" "existing_worker" {
-  hostname           = "existing-server-02"
-  category           = bcm_cmdevice_category.compute.id
-  management_network = data.bcm_cmnet_networks.all.networks[0].id
-  mac                = "00:11:22:33:44:71"
+  hostname = "existing-server-02"
+  category = bcm_cmdevice_category.compute.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:71"
+    network  = data.bcm_cmnet_networks.all.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   power_control = "ipmi"
 
@@ -417,7 +494,6 @@ output "etcd_cluster" {
 
 - `category` (String) Category UUID reference
 - `hostname` (String) Device hostname (RFC 1123 DNS label: lowercase alphanumeric and hyphens, 1-63 chars)
-- `mac` (String) Primary MAC address (format: 00:11:22:33:44:55)
 
 ### Optional
 
@@ -427,9 +503,10 @@ output "etcd_cluster" {
 - `default_gateway_metric` (Number) Default gateway metric/priority (lower is preferred)
 - `etcd_host_role` (Block List) Etcd host role configuration. Defines this device as a member of an EtcdCluster. Each etcd_host_role block associates the device with one EtcdCluster as an etcd node. (see [below for nested schema](#nestedblock--etcd_host_role))
 - `force` (Boolean) Force operation (override BCM validation warnings)
-- `interfaces` (Block List) Network interface configurations for the device. When specified, provides full control over interface setup. Each interface can be physical, bond, or BMC type. (see [below for nested schema](#nestedblock--interfaces))
+- `interfaces` (Block List) Network interface configurations for the device. At least one interface is required. Each interface can be physical, bond, or BMC type. (see [below for nested schema](#nestedblock--interfaces))
 - `kernel_parameters` (String) Kernel boot parameters
 - `kubelet_role` (Block List) Kubernetes kubelet role configuration. Defines this device as a member of a KubeCluster. Each kubelet_role block associates the device with one KubeCluster as a control plane node, worker node, or both. (see [below for nested schema](#nestedblock--kubelet_role))
+- `mac` (String) Device MAC address, computed from the first interface. Can be set explicitly to override.
 - `management_network` (String) Management network UUID reference (may be reset by BCM, required for device creation)
 - `notes` (String) Device notes/description
 - `part_number` (String) Hardware part number

--- a/examples/actions/bcm_cmdevice_power/lifecycle.tf
+++ b/examples/actions/bcm_cmdevice_power/lifecycle.tf
@@ -30,10 +30,17 @@ data "bcm_cmnet_networks" "mgmt" {
 
 # Create a new device and automatically power it on
 resource "bcm_cmdevice_device" "new_worker" {
-  hostname           = "citest-lifecycle-node"
-  mac                = "00:11:22:33:44:55"
-  category           = data.bcm_cmdevice_categories.compute.categories[0].uuid
-  management_network = data.bcm_cmnet_networks.mgmt.networks[0].uuid
+  hostname = "citest-lifecycle-node"
+  category = data.bcm_cmdevice_categories.compute.categories[0].uuid
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:55"
+    network  = data.bcm_cmnet_networks.mgmt.networks[0].uuid
+    bootable = true
+    dhcp     = true
+  }
 
   # Lifecycle trigger to power on after device creation
   # NOTE: This syntax is subject to change in Terraform 1.14+

--- a/examples/resources/bcm_cmdevice_device/README.md
+++ b/examples/resources/bcm_cmdevice_device/README.md
@@ -7,7 +7,7 @@ This directory contains comprehensive examples for the `bcm_cmdevice_device` res
 ### basic.tf
 Minimal device configuration demonstrating:
 - Basic compute device setup
-- Required fields: hostname, mac, category, management_network
+- Required fields: hostname, category, interfaces (at least one)
 - Data source lookups for category and network
 
 **Use case:** Quick device provisioning with minimal configuration.
@@ -124,9 +124,16 @@ These are created first, then used by device resources.
 
 ### MAC Address Management
 
-Each device requires a unique MAC address:
+Each device requires at least one interface with a unique MAC address:
 ```hcl
-mac = "00:11:22:33:44:55"  # Unique per device
+interfaces {
+  name     = "eth0"
+  type     = "physical"
+  mac      = "00:11:22:33:44:55"  # Unique per device
+  network  = data.bcm_cmnet_networks.management.networks[0].id
+  bootable = true
+  dhcp     = true
+}
 ```
 
 For testing, use the AA-FF range to avoid conflicts:
@@ -164,7 +171,7 @@ resource "bcm_cmdevice_device" "example" {
 
 ### Network Configuration
 
-Management network is required:
+Network assignment is configured per-interface via the `interfaces` block:
 ```hcl
 data "bcm_cmnet_networks" "management" {
   filter {
@@ -173,8 +180,17 @@ data "bcm_cmnet_networks" "management" {
 }
 
 resource "bcm_cmdevice_device" "example" {
-  management_network = data.bcm_cmnet_networks.management.networks[0].id
-  # ...
+  hostname = "example-node"
+  category = bcm_cmdevice_category.compute.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:55"
+    network  = data.bcm_cmnet_networks.management.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 }
 ```
 

--- a/examples/resources/bcm_cmdevice_device/basic.tf
+++ b/examples/resources/bcm_cmdevice_device/basic.tf
@@ -36,10 +36,17 @@ resource "bcm_cmdevice_category" "basic_category" {
 # Note: partition is NOT specified because the category has a software_image_proxy
 # which provides the partition automatically
 resource "bcm_cmdevice_device" "basic" {
-  hostname           = "citest-device-${local.test_suffix}"
-  mac                = "00:11:22:33:44:AA"
-  category           = bcm_cmdevice_category.basic_category.id
-  management_network = data.bcm_cmnet_networks.management.networks[0].id
+  hostname = "citest-device-${local.test_suffix}"
+  category = bcm_cmdevice_category.basic_category.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:AA"
+    network  = data.bcm_cmnet_networks.management.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   notes = "Basic test device (run: ${local.test_suffix})"
 

--- a/examples/resources/bcm_cmdevice_device/import.tf
+++ b/examples/resources/bcm_cmdevice_device/import.tf
@@ -12,17 +12,53 @@ data "bcm_cmnet_networks" "management" {
   }
 }
 
-# Import an existing device using its UUID
-# terraform import bcm_cmdevice_device.example <device-uuid>
+# =============================================================================
+# Example 1: Import with known values
+# =============================================================================
+# When you know the device's MAC and network, specify them directly.
+#
+# Step 1: terraform import bcm_cmdevice_device.known <device-uuid>
+# Step 2: terraform plan (verify no unexpected changes)
 
-resource "bcm_cmdevice_device" "example" {
-  hostname = "citest-import-example"
+resource "bcm_cmdevice_device" "known" {
+  hostname = "citest-import-known"
   category = one(data.bcm_cmdevice_categories.default.categories[*].id)
 
   interfaces {
     name     = "eth0"
     type     = "physical"
     mac      = "00:11:22:33:44:CC"
+    network  = one(data.bcm_cmnet_networks.management.networks[*].id)
+    bootable = true
+    dhcp     = true
+  }
+}
+
+# =============================================================================
+# Example 2: Import using data source lookup
+# =============================================================================
+# When importing an existing device, use the nodes data source to discover
+# the device's current MAC and interface configuration. This avoids
+# hardcoding values that may differ from what BCM has.
+#
+# Step 1: terraform apply -target=data.bcm_cmdevice_nodes.existing
+# Step 2: terraform import bcm_cmdevice_device.discovered <device-uuid>
+# Step 3: terraform plan (verify no unexpected changes)
+
+data "bcm_cmdevice_nodes" "existing" {
+  filter {
+    hostname_pattern = "existing-server-01"
+  }
+}
+
+resource "bcm_cmdevice_device" "discovered" {
+  hostname = data.bcm_cmdevice_nodes.existing.nodes[0].hostname
+  category = one(data.bcm_cmdevice_categories.default.categories[*].id)
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = data.bcm_cmdevice_nodes.existing.nodes[0].mac
     network  = one(data.bcm_cmnet_networks.management.networks[*].id)
     bootable = true
     dhcp     = true

--- a/examples/resources/bcm_cmdevice_device/import.tf
+++ b/examples/resources/bcm_cmdevice_device/import.tf
@@ -16,8 +16,15 @@ data "bcm_cmnet_networks" "management" {
 # terraform import bcm_cmdevice_device.example <device-uuid>
 
 resource "bcm_cmdevice_device" "example" {
-  hostname           = "citest-import-example"
-  mac                = "00:11:22:33:44:CC"
-  category           = one(data.bcm_cmdevice_categories.default.categories[*].id)
-  management_network = one(data.bcm_cmnet_networks.management.networks[*].id)
+  hostname = "citest-import-example"
+  category = one(data.bcm_cmdevice_categories.default.categories[*].id)
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:CC"
+    network  = one(data.bcm_cmnet_networks.management.networks[*].id)
+    bootable = true
+    dhcp     = true
+  }
 }

--- a/examples/resources/bcm_cmdevice_device/ipmi.tf
+++ b/examples/resources/bcm_cmdevice_device/ipmi.tf
@@ -15,10 +15,17 @@ data "bcm_cmnet_networks" "management" {
 
 # Example: IPMI-enabled device with power control and network configuration
 resource "bcm_cmdevice_device" "ipmi" {
-  hostname           = "citest-compute-ipmi"
-  mac                = "00:11:22:33:44:BB"
-  category           = try(data.bcm_cmdevice_categories.default.categories[0].id, null)
-  management_network = try(data.bcm_cmnet_networks.management.networks[0].id, null)
+  hostname = "citest-compute-ipmi"
+  category = try(data.bcm_cmdevice_categories.default.categories[0].id, null)
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:BB"
+    network  = try(data.bcm_cmnet_networks.management.networks[0].id, null)
+    bootable = true
+    dhcp     = true
+  }
 
   # Power control via IPMI
   power_control = "ipmi"

--- a/examples/resources/bcm_cmdevice_device/resource.tf
+++ b/examples/resources/bcm_cmdevice_device/resource.tf
@@ -21,20 +21,34 @@ resource "bcm_cmpart_softwareimage" "ubuntu_compute" {
 
 # Example 1: Basic compute device with minimal configuration
 resource "bcm_cmdevice_device" "compute_basic" {
-  hostname           = "citest-compute-node-01"
-  mac                = "00:11:22:33:44:55"
-  category           = bcm_cmdevice_category.compute.id
-  management_network = data.bcm_cmnet_networks.all.networks[0].id
+  hostname = "citest-compute-node-01"
+  category = bcm_cmdevice_category.compute.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:55"
+    network  = data.bcm_cmnet_networks.all.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   notes = "Basic compute node managed by Terraform"
 }
 
 # Example 2: Compute device with custom kernel parameters and boot configuration
 resource "bcm_cmdevice_device" "compute_custom" {
-  hostname           = "citest-compute-node-02"
-  mac                = "00:11:22:33:44:56"
-  category           = bcm_cmdevice_category.compute.id
-  management_network = data.bcm_cmnet_networks.all.networks[0].id
+  hostname = "citest-compute-node-02"
+  category = bcm_cmdevice_category.compute.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:56"
+    network  = data.bcm_cmnet_networks.all.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   # Boot configuration
   boot_loader       = "pxelinux"
@@ -45,10 +59,17 @@ resource "bcm_cmdevice_device" "compute_custom" {
 
 # Example 3: IPMI-enabled device with power control and network configuration
 resource "bcm_cmdevice_device" "compute_ipmi" {
-  hostname           = "citest-compute-node-03"
-  mac                = "00:11:22:33:44:57"
-  category           = bcm_cmdevice_category.compute.id
-  management_network = data.bcm_cmnet_networks.all.networks[0].id
+  hostname = "citest-compute-node-03"
+  category = bcm_cmdevice_category.compute.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:57"
+    network  = data.bcm_cmnet_networks.all.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   # Power control via IPMI
   power_control = "ipmi"
@@ -70,10 +91,17 @@ resource "bcm_cmdevice_device" "compute_ipmi" {
 
 # Example 4: GPU compute node with multiple network interfaces
 resource "bcm_cmdevice_device" "gpu_node" {
-  hostname           = "citest-gpu-node-01"
-  mac                = "00:11:22:33:44:58"
-  category           = bcm_cmdevice_category.compute.id
-  management_network = data.bcm_cmnet_networks.all.networks[0].id
+  hostname = "citest-gpu-node-01"
+  category = bcm_cmdevice_category.compute.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:58"
+    network  = data.bcm_cmnet_networks.all.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   # Power control
   power_control = "ipmi"
@@ -95,10 +123,17 @@ resource "bcm_cmdevice_device" "gpu_node" {
 
 # Example 5: Storage node with custom partition configuration
 resource "bcm_cmdevice_device" "storage_node" {
-  hostname           = "citest-storage-node-01"
-  mac                = "00:11:22:33:44:59"
-  category           = bcm_cmdevice_category.compute.id
-  management_network = data.bcm_cmnet_networks.all.networks[0].id
+  hostname = "citest-storage-node-01"
+  category = bcm_cmdevice_category.compute.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:59"
+    network  = data.bcm_cmnet_networks.all.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   # Power control
   power_control = "ipmi"
@@ -149,10 +184,17 @@ resource "bcm_cmkube_cluster" "production" {
 # Example 6: Kubernetes control plane node with kubelet_role
 # This device runs the Kubernetes control plane components (API server, etc.)
 resource "bcm_cmdevice_device" "k8s_control_plane" {
-  hostname           = "citest-k8s-cp-01"
-  mac                = "00:11:22:33:44:60"
-  category           = bcm_cmdevice_category.compute.id
-  management_network = data.bcm_cmnet_networks.all.networks[0].id
+  hostname = "citest-k8s-cp-01"
+  category = bcm_cmdevice_category.compute.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:60"
+    network  = data.bcm_cmnet_networks.all.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   # Power control
   power_control = "ipmi"
@@ -174,10 +216,17 @@ resource "bcm_cmdevice_device" "k8s_control_plane" {
 # Example 7: Kubernetes worker node with kubelet_role
 # This device runs application workloads scheduled by Kubernetes
 resource "bcm_cmdevice_device" "k8s_worker" {
-  hostname           = "citest-k8s-worker-01"
-  mac                = "00:11:22:33:44:61"
-  category           = bcm_cmdevice_category.compute.id
-  management_network = data.bcm_cmnet_networks.all.networks[0].id
+  hostname = "citest-k8s-worker-01"
+  category = bcm_cmdevice_category.compute.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:61"
+    network  = data.bcm_cmnet_networks.all.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   # Power control
   power_control = "ipmi"
@@ -199,10 +248,17 @@ resource "bcm_cmdevice_device" "k8s_worker" {
 # Example 8: Etcd host node with etcd_host_role
 # This device hosts an etcd cluster member for distributed key-value storage
 resource "bcm_cmdevice_device" "etcd_host" {
-  hostname           = "citest-etcd-host-01"
-  mac                = "00:11:22:33:44:62"
-  category           = bcm_cmdevice_category.compute.id
-  management_network = data.bcm_cmnet_networks.all.networks[0].id
+  hostname = "citest-etcd-host-01"
+  category = bcm_cmdevice_category.compute.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:62"
+    network  = data.bcm_cmnet_networks.all.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   # Power control
   power_control = "ipmi"
@@ -222,10 +278,17 @@ resource "bcm_cmdevice_device" "etcd_host" {
 # Example 9: Combined control plane node with both roles
 # This device runs both etcd and Kubernetes control plane (common in small clusters)
 resource "bcm_cmdevice_device" "k8s_combined_cp" {
-  hostname           = "citest-k8s-combined-01"
-  mac                = "00:11:22:33:44:63"
-  category           = bcm_cmdevice_category.compute.id
-  management_network = data.bcm_cmnet_networks.all.networks[0].id
+  hostname = "citest-k8s-combined-01"
+  category = bcm_cmdevice_category.compute.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:63"
+    network  = data.bcm_cmnet_networks.all.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   # Power control
   power_control = "ipmi"
@@ -268,10 +331,17 @@ resource "bcm_cmdevice_device" "k8s_combined_cp" {
 # Import first: terraform import bcm_cmdevice_device.existing_cp <uuid>
 resource "bcm_cmdevice_device" "existing_cp" {
   # These values must match the existing device after import
-  hostname           = "existing-server-01"
-  category           = bcm_cmdevice_category.compute.id
-  management_network = data.bcm_cmnet_networks.all.networks[0].id
-  mac                = "00:11:22:33:44:70"
+  hostname = "existing-server-01"
+  category = bcm_cmdevice_category.compute.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:70"
+    network  = data.bcm_cmnet_networks.all.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   # Existing device settings are preserved
   power_control = "ipmi"
@@ -294,10 +364,17 @@ resource "bcm_cmdevice_device" "existing_cp" {
 # Example 11: Existing device converted to Kubernetes worker
 # Import first: terraform import bcm_cmdevice_device.existing_worker <uuid>
 resource "bcm_cmdevice_device" "existing_worker" {
-  hostname           = "existing-server-02"
-  category           = bcm_cmdevice_category.compute.id
-  management_network = data.bcm_cmnet_networks.all.networks[0].id
-  mac                = "00:11:22:33:44:71"
+  hostname = "existing-server-02"
+  category = bcm_cmdevice_category.compute.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:71"
+    network  = data.bcm_cmnet_networks.all.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   power_control = "ipmi"
 

--- a/examples/resources/bcm_cmdevice_device/resource.tf
+++ b/examples/resources/bcm_cmdevice_device/resource.tf
@@ -89,11 +89,14 @@ resource "bcm_cmdevice_device" "compute_ipmi" {
   notes = "IPMI-enabled compute node with power management"
 }
 
-# Example 4: GPU compute node with multiple network interfaces
+# Example 4: GPU compute node with multiple interfaces
+# Management NIC for provisioning, high-speed data NIC for GPU traffic,
+# and a BMC interface for out-of-band management.
 resource "bcm_cmdevice_device" "gpu_node" {
   hostname = "citest-gpu-node-01"
   category = bcm_cmdevice_category.compute.id
 
+  # Management interface - used for PXE boot and provisioning
   interfaces {
     name     = "eth0"
     type     = "physical"
@@ -103,12 +106,28 @@ resource "bcm_cmdevice_device" "gpu_node" {
     dhcp     = true
   }
 
-  # Power control
+  # High-speed data interface - for GPU-to-GPU and storage traffic
+  interfaces {
+    name = "eth1"
+    type = "physical"
+    mac  = "00:11:22:33:44:68"
+    dhcp = true
+  }
+
+  # BMC interface - out-of-band IPMI management
+  interfaces {
+    name = "ipmi"
+    type = "bmc"
+    ip   = "192.168.100.11"
+    dhcp = false
+  }
+
+  # Power control via IPMI (uses BMC interface)
   power_control = "ipmi"
 
   # Network configuration for high-performance networking
   default_gateway        = "192.168.1.1"
-  default_gateway_metric = 50 # Lower metric for preferred route
+  default_gateway_metric = 50
 
   # Boot configuration with GPU-specific parameters
   boot_loader       = "pxelinux"
@@ -118,14 +137,16 @@ resource "bcm_cmdevice_device" "gpu_node" {
   serial_number = "SN-GPU-001"
   part_number   = "PN-GPU-NODE-001"
 
-  notes = "GPU compute node with NVIDIA drivers and RDMA networking"
+  notes = "GPU compute node with management, data, and BMC interfaces"
 }
 
-# Example 5: Storage node with custom partition configuration
+# Example 5: Storage node with bonded interfaces
+# Uses a bond for redundancy on the storage network.
 resource "bcm_cmdevice_device" "storage_node" {
   hostname = "citest-storage-node-01"
   category = bcm_cmdevice_category.compute.id
 
+  # Management interface for provisioning
   interfaces {
     name     = "eth0"
     type     = "physical"
@@ -133,6 +154,28 @@ resource "bcm_cmdevice_device" "storage_node" {
     network  = data.bcm_cmnet_networks.all.networks[0].id
     bootable = true
     dhcp     = true
+  }
+
+  # Member interfaces for bond (no network assignment - managed by bond)
+  interfaces {
+    name = "eth1"
+    type = "physical"
+    mac  = "00:11:22:33:44:69"
+  }
+
+  interfaces {
+    name = "eth2"
+    type = "physical"
+    mac  = "00:11:22:33:44:79"
+  }
+
+  # Bonded interface for storage traffic (uses eth1 + eth2)
+  interfaces {
+    name      = "bond0"
+    type      = "bond"
+    dhcp      = true
+    members   = ["eth1", "eth2"]
+    bond_mode = "802.3ad"
   }
 
   # Power control
@@ -150,7 +193,7 @@ resource "bcm_cmdevice_device" "storage_node" {
   serial_number = "SN-STORAGE-001"
   part_number   = "PN-STORAGE-NODE-001"
 
-  notes = "Storage node for Ceph cluster"
+  notes = "Storage node with bonded interfaces for Ceph cluster"
 }
 
 # =============================================================================

--- a/examples/resources/bcm_cmdevice_device/with_roles.tf
+++ b/examples/resources/bcm_cmdevice_device/with_roles.tf
@@ -54,10 +54,17 @@ resource "bcm_cmdevice_category" "roles_category" {
 
 # Create device with roles assigned BY NAME
 resource "bcm_cmdevice_device" "with_roles" {
-  hostname           = "citest-roles-${local.test_suffix}"
-  mac                = "00:11:22:33:44:BB"
-  category           = bcm_cmdevice_category.roles_category.id
-  management_network = data.bcm_cmnet_networks.management.networks[0].id
+  hostname = "citest-roles-${local.test_suffix}"
+  category = bcm_cmdevice_category.roles_category.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:BB"
+    network  = data.bcm_cmnet_networks.management.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   # Assign roles by name - provider validates against BCM cluster
   roles = local.device_roles

--- a/internal/provider/error_messages.go
+++ b/internal/provider/error_messages.go
@@ -30,11 +30,11 @@ func BuildDependencyError(resourceType, resourceName, dependentType string, iden
 	shown := minInt(count, maxShow)
 
 	for i := 0; i < shown; i++ {
-		dependentList.WriteString(fmt.Sprintf("  - %s (uuid: %s)\n", identifiers[i].Name, identifiers[i].UUID))
+		fmt.Fprintf(&dependentList, "  - %s (uuid: %s)\n", identifiers[i].Name, identifiers[i].UUID)
 	}
 
 	if count > maxShow {
-		dependentList.WriteString(fmt.Sprintf("  ... (showing first %d of %d)\n", maxShow, count))
+		fmt.Fprintf(&dependentList, "  ... (showing first %d of %d)\n", maxShow, count)
 	}
 
 	// Build resolution options based on resource type

--- a/internal/provider/resource_cmdevice_device.go
+++ b/internal/provider/resource_cmdevice_device.go
@@ -13,11 +13,14 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -25,8 +28,9 @@ import (
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var (
-	_ resource.Resource                = &CMDeviceDeviceResource{}
-	_ resource.ResourceWithImportState = &CMDeviceDeviceResource{}
+	_ resource.Resource                     = &CMDeviceDeviceResource{}
+	_ resource.ResourceWithImportState      = &CMDeviceDeviceResource{}
+	_ resource.ResourceWithValidateConfig   = &CMDeviceDeviceResource{}
 )
 
 // CMDeviceDeviceResource defines the resource implementation.
@@ -40,11 +44,11 @@ type CMDeviceDeviceResourceModel struct {
 	ID       types.String `tfsdk:"id"`       // Computed, same as UUID
 	UUID     types.String `tfsdk:"uuid"`     // Computed, BCM-assigned
 	Hostname types.String `tfsdk:"hostname"` // Required, RFC 1123 validation
-	MAC      types.String `tfsdk:"mac"`      // Required, MAC address validation
+	MAC      types.String `tfsdk:"mac"`      // Optional+Computed, derived from first interface
 
 	// References (required)
 	Category          types.String `tfsdk:"category"`           // Required, UUID reference
-	ManagementNetwork types.String `tfsdk:"management_network"` // Required, UUID reference
+	ManagementNetwork types.String `tfsdk:"management_network"` // Optional+Computed, UUID reference
 	Partition         types.String `tfsdk:"partition"`          // Optional, UUID reference (uses default if not set)
 
 	// Optional configuration
@@ -70,8 +74,7 @@ type CMDeviceDeviceResourceModel struct {
 	BaseType     types.String `tfsdk:"base_type"`     // Computed, always "Device"
 	ChildType    types.String `tfsdk:"child_type"`    // Computed, BCM-determined
 
-	// Interfaces block - NEW for multi-interface support
-	// When specified, takes precedence over legacy mac/management_network
+	// Interfaces block - at least one interface is required
 	Interfaces []DeviceInterfaceModel `tfsdk:"interfaces"`
 
 	// Roles - set of role UUIDs assigned to this device
@@ -99,7 +102,7 @@ func (r *CMDeviceDeviceResource) Schema(ctx context.Context, req resource.Schema
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Manages a BCM device (compute node) in the cluster.\n\n" +
 			"Devices represent physical or virtual nodes that can be provisioned and managed by BCM. " +
-			"Each device requires a unique hostname, MAC address, category assignment, and management network configuration.",
+			"Each device requires a unique hostname, category assignment, and at least one network interface.",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -121,8 +124,12 @@ func (r *CMDeviceDeviceResource) Schema(ctx context.Context, req resource.Schema
 				},
 			},
 			"mac": schema.StringAttribute{
-				Required:            true,
-				MarkdownDescription: "Primary MAC address (format: 00:11:22:33:44:55)",
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Device MAC address, computed from the first interface. Can be set explicitly to override.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(
 						regexp.MustCompile(`^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$`),
@@ -247,8 +254,11 @@ func (r *CMDeviceDeviceResource) Schema(ctx context.Context, req resource.Schema
 		Blocks: map[string]schema.Block{
 			"interfaces": schema.ListNestedBlock{
 				MarkdownDescription: "Network interface configurations for the device. " +
-					"When specified, provides full control over interface setup. " +
+					"At least one interface is required. " +
 					"Each interface can be physical, bond, or BMC type.",
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+				},
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"name": schema.StringAttribute{
@@ -481,6 +491,26 @@ func (r *CMDeviceDeviceResource) Configure(ctx context.Context, req resource.Con
 	r.ConfigureResource(req, resp)
 }
 
+// ValidateConfig ensures at least one interface is defined.
+// Block-level validators on ListNestedBlock may not fire when the block is absent,
+// so we enforce the requirement here.
+func (r *CMDeviceDeviceResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config CMDeviceDeviceResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if len(config.Interfaces) == 0 {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("interfaces"),
+			"At least one interface is required",
+			"The interfaces block must contain at least one network interface configuration. "+
+				"Each device needs at least one interface for network connectivity.",
+		)
+	}
+}
+
 // Create creates the device resource.
 func (r *CMDeviceDeviceResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	if r.Client == nil {
@@ -556,7 +586,8 @@ func (r *CMDeviceDeviceResource) Create(ctx context.Context, req resource.Create
 
 	// Build device entity for BCM API (with generated UUID and resolved partition)
 	// Partition field is always included as BCM requires it
-	deviceEntity := r.buildDeviceAPIEntity(plan, newUUID, partitionUUID)
+	// nil for existingInterfaces since this is a new device
+	deviceEntity := r.buildDeviceAPIEntityWithExisting(plan, newUUID, partitionUUID, nil)
 
 	// Lookup and add roles to the entity (requires BCM API access to get full role objects)
 	if err := r.lookupAndBuildRolesForEntity(ctx, plan, deviceEntity); err != nil {
@@ -682,7 +713,15 @@ func (r *CMDeviceDeviceResource) Create(ctx context.Context, req resource.Create
 		state.Partition = types.StringValue(partitionUUID)
 	}
 
+	// Compute mac from first interface if not explicitly set or BCM returned empty
+	if (state.MAC.IsNull() || state.MAC.ValueString() == "") && len(state.Interfaces) > 0 {
+		if !state.Interfaces[0].MAC.IsNull() {
+			state.MAC = state.Interfaces[0].MAC
+		}
+	}
+
 	// BCM returns nil UUID for management_network - preserve the configured value
+	// Still needed when user explicitly sets management_network as an optional field
 	if !plan.ManagementNetwork.IsNull() && !plan.ManagementNetwork.IsUnknown() {
 		if state.ManagementNetwork.IsNull() || state.ManagementNetwork.ValueString() == "00000000-0000-0000-0000-000000000000" {
 			state.ManagementNetwork = plan.ManagementNetwork
@@ -716,15 +755,8 @@ func (r *CMDeviceDeviceResource) Create(ctx context.Context, req resource.Create
 		state.Roles = types.SetNull(types.StringType)
 	}
 
-	// Handle interfaces in state based on mode
-	if len(plan.Interfaces) > 0 {
-		// Interfaces mode: Normalize interface order to match plan order (prevents spurious diffs)
-		state.Interfaces = normalizeInterfaceOrder(state.Interfaces, plan.Interfaces)
-	} else {
-		// Legacy mode: Don't populate interfaces in state (user didn't define interfaces block)
-		// BCM creates interfaces automatically, but we don't expose them in legacy mode
-		state.Interfaces = nil
-	}
+	// Normalize interface order to match plan order (prevents spurious diffs)
+	state.Interfaces = normalizeInterfaceOrder(state.Interfaces, plan.Interfaces)
 
 	// Handle Kubernetes roles - preserve state with computed defaults merged
 	// Only include roles if user defined them in plan
@@ -935,6 +967,13 @@ func (r *CMDeviceDeviceResource) Read(ctx context.Context, req resource.ReadRequ
 	// Preserve write-only fields that BCM doesn't return
 	newState.Force = state.Force
 
+	// Compute mac from first interface if BCM returned empty
+	if (newState.MAC.IsNull() || newState.MAC.ValueString() == "") && len(newState.Interfaces) > 0 {
+		if !newState.Interfaces[0].MAC.IsNull() {
+			newState.MAC = newState.Interfaces[0].MAC
+		}
+	}
+
 	// CRITICAL FIX FOR IMPORT: Handle optional+computed fields differently for import vs normal Read
 	// During import (state is empty), we should NOT preserve null values - instead use what BCM returns
 	// During normal Read (state has values), preserve null if user didn't explicitly set the field
@@ -945,7 +984,7 @@ func (r *CMDeviceDeviceResource) Read(ctx context.Context, req resource.ReadRequ
 		// Normal Read path: Preserve null values from state to avoid drift
 
 		// BCM returns nil UUID for management_network - preserve the configured value
-		// when BCM returns "00000000-0000-0000-0000-000000000000"
+		// Still needed when user explicitly sets management_network as an optional field
 		if !state.ManagementNetwork.IsNull() && !state.ManagementNetwork.IsUnknown() {
 			if newState.ManagementNetwork.IsNull() || newState.ManagementNetwork.ValueString() == "00000000-0000-0000-0000-000000000000" {
 				newState.ManagementNetwork = state.ManagementNetwork
@@ -999,24 +1038,10 @@ func (r *CMDeviceDeviceResource) Read(ctx context.Context, req resource.ReadRequ
 		})
 	}
 
-	// Handle interfaces based on mode
-	// During import (isImport=true), always populate interfaces from BCM
-	// During normal read, use state to determine if user used interfaces block
-	if isImport {
-		// Import: Keep interfaces from BCM API response (already parsed in newState)
-		tflog.Debug(ctx, "Import path - keeping interfaces from BCM API", map[string]interface{}{
-			"interface_count": len(newState.Interfaces),
-		})
-	} else if len(state.Interfaces) > 0 {
-		// Interfaces mode: normalize order and merge bond-specific fields from state
-		// BCM doesn't return members/bond_mode fields, so we need to preserve them from state
-		if len(newState.Interfaces) > 0 {
-			newState.Interfaces = normalizeInterfaceOrder(newState.Interfaces, state.Interfaces)
-		}
-	} else {
-		// Legacy mode: Don't populate interfaces in state (user didn't define interfaces block)
-		// This maintains backward compatibility with existing configs
-		newState.Interfaces = nil
+	// Normalize interface order to match state (prevents spurious diffs)
+	// During import, keep interfaces from BCM as-is; during normal read, merge with state
+	if !isImport && len(state.Interfaces) > 0 && len(newState.Interfaces) > 0 {
+		newState.Interfaces = normalizeInterfaceOrder(newState.Interfaces, state.Interfaces)
 	}
 
 	// Handle roles - preserve null from state if user didn't specify roles (non-import path)
@@ -1196,7 +1221,15 @@ func (r *CMDeviceDeviceResource) Update(ctx context.Context, req resource.Update
 	// Preserve plan values for fields not persisted by BCM or modified during updates
 	newState.Force = plan.Force
 
+	// Compute mac from first interface if not explicitly set or BCM returned empty
+	if (newState.MAC.IsNull() || newState.MAC.ValueString() == "") && len(newState.Interfaces) > 0 {
+		if !newState.Interfaces[0].MAC.IsNull() {
+			newState.MAC = newState.Interfaces[0].MAC
+		}
+	}
+
 	// BCM sets management_network to nil UUID - preserve plan value if set, otherwise use state or null
+	// Still needed when user explicitly sets management_network as an optional field
 	if !plan.ManagementNetwork.IsNull() && !plan.ManagementNetwork.IsUnknown() {
 		newState.ManagementNetwork = plan.ManagementNetwork
 	} else if !state.ManagementNetwork.IsNull() && !state.ManagementNetwork.IsUnknown() {
@@ -1249,15 +1282,8 @@ func (r *CMDeviceDeviceResource) Update(ctx context.Context, req resource.Update
 		newState.Roles = types.SetNull(types.StringType)
 	}
 
-	// Handle interfaces in state based on mode
-	if len(plan.Interfaces) > 0 {
-		// Interfaces mode: Normalize interface order to match plan order (prevents spurious diffs)
-		newState.Interfaces = normalizeInterfaceOrder(newState.Interfaces, plan.Interfaces)
-	} else {
-		// Legacy mode: Don't populate interfaces in state (user didn't define interfaces block)
-		// BCM creates/maintains interfaces, but we don't expose them in legacy mode
-		newState.Interfaces = nil
-	}
+	// Normalize interface order to match plan order (prevents spurious diffs)
+	newState.Interfaces = normalizeInterfaceOrder(newState.Interfaces, plan.Interfaces)
 
 	// Handle Kubernetes roles - preserve state with computed defaults merged
 	// Only include roles if user defined them in plan
@@ -1329,68 +1355,27 @@ func (r *CMDeviceDeviceResource) ImportState(ctx context.Context, req resource.I
 	})
 }
 
-// buildDeviceAPIEntity constructs BCM API entity from Terraform model.
-func (r *CMDeviceDeviceResource) buildDeviceAPIEntity(plan CMDeviceDeviceResourceModel, uuid string, partitionUUID string) map[string]interface{} {
-	return r.buildDeviceAPIEntityWithExisting(plan, uuid, partitionUUID, nil)
-}
-
 // buildDeviceAPIEntityWithExisting constructs BCM API entity, preserving interface UUIDs from existing state.
 func (r *CMDeviceDeviceResource) buildDeviceAPIEntityWithExisting(plan CMDeviceDeviceResourceModel, deviceUUID string, partitionUUID string, existingInterfaces []DeviceInterfaceModel) map[string]interface{} {
-	var interfaces []interface{}
-	var provisioningInterfaceUUID string
+	// Build interfaces from the interfaces block
+	interfaces := buildInterfacesAPIArray(plan.Interfaces, existingInterfaces)
+	provisioningInterfaceUUID := getProvisioningInterfaceUUID(plan.Interfaces)
 
-	// Check if using interfaces block or legacy mode
-	if len(plan.Interfaces) > 0 {
-		// NEW: Build interfaces from the interfaces block
-		interfaces = buildInterfacesAPIArray(plan.Interfaces, existingInterfaces)
-		provisioningInterfaceUUID = getProvisioningInterfaceUUID(plan.Interfaces)
-
-		// If no provisioning interface found from plan, get from built interfaces
-		if provisioningInterfaceUUID == "" && len(interfaces) > 0 {
-			if firstIface, ok := interfaces[0].(map[string]interface{}); ok {
-				if ifaceUUID, ok := firstIface["uuid"].(string); ok {
-					provisioningInterfaceUUID = ifaceUUID
-				}
+	// If no provisioning interface found from plan, get from built interfaces
+	if provisioningInterfaceUUID == "" && len(interfaces) > 0 {
+		if firstIface, ok := interfaces[0].(map[string]interface{}); ok {
+			if ifaceUUID, ok := firstIface["uuid"].(string); ok {
+				provisioningInterfaceUUID = ifaceUUID
 			}
 		}
-	} else {
-		// LEGACY: Create a basic network interface from mac/management_network
-		interfaceUUID := uuid.New().String()
-
-		// Use management_network from plan if specified, otherwise nil UUID
-		networkUUID := "00000000-0000-0000-0000-000000000000"
-		if !plan.ManagementNetwork.IsNull() && !plan.ManagementNetwork.IsUnknown() {
-			networkUUID = plan.ManagementNetwork.ValueString()
-		}
-
-		networkInterface := map[string]interface{}{
-			"baseType":             "NetworkInterface",
-			"childType":            "NetworkPhysicalInterface",
-			"mac":                  plan.MAC.ValueString(),
-			"network":              networkUUID,
-			"name":                 "eth0",
-			"dhcp":                 true,
-			"bootable":             true,
-			"startIf":              "ALWAYS",
-			"modified":             true,
-			"to_be_removed":        false,
-			"revision":             "",
-			"uuid":                 interfaceUUID,
-			"ipv6Ip":               "::0",
-			"ipv6Dhcp":             false,
-			"bringupduringinstall": "NO",
-			"cardtype":             "Ethernet",
-		}
-
-		interfaces = []interface{}{networkInterface}
-		provisioningInterfaceUUID = interfaceUUID
 	}
 
-	// Get MAC for device entity - use first interface MAC if interfaces block, else legacy mac field
+	// Device MAC: explicit top-level mac if set, otherwise first interface MAC
 	deviceMAC := ""
 	if len(plan.Interfaces) > 0 && !plan.Interfaces[0].MAC.IsNull() {
 		deviceMAC = plan.Interfaces[0].MAC.ValueString()
-	} else if !plan.MAC.IsNull() && !plan.MAC.IsUnknown() {
+	}
+	if !plan.MAC.IsNull() && !plan.MAC.IsUnknown() {
 		deviceMAC = plan.MAC.ValueString()
 	}
 

--- a/internal/provider/resource_cmdevice_device.go
+++ b/internal/provider/resource_cmdevice_device.go
@@ -28,9 +28,9 @@ import (
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var (
-	_ resource.Resource                     = &CMDeviceDeviceResource{}
-	_ resource.ResourceWithImportState      = &CMDeviceDeviceResource{}
-	_ resource.ResourceWithValidateConfig   = &CMDeviceDeviceResource{}
+	_ resource.Resource                   = &CMDeviceDeviceResource{}
+	_ resource.ResourceWithImportState    = &CMDeviceDeviceResource{}
+	_ resource.ResourceWithValidateConfig = &CMDeviceDeviceResource{}
 )
 
 // CMDeviceDeviceResource defines the resource implementation.

--- a/internal/provider/resource_cmdevice_device_idempotency_test.go
+++ b/internal/provider/resource_cmdevice_device_idempotency_test.go
@@ -491,10 +491,17 @@ resource "bcm_cmdevice_category" "test" {
 }
 
 resource "bcm_cmdevice_device" "test" {
-  hostname           = %[6]q
-  mac                = %[8]q
-  category           = bcm_cmdevice_category.test.id
-  management_network = data.bcm_cmnet_networks.management.networks[0].id
+  hostname = %[6]q
+  category = bcm_cmdevice_category.test.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = %[8]q
+    network  = data.bcm_cmnet_networks.management.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   depends_on = [bcm_cmdevice_category.test]
 }
@@ -542,12 +549,19 @@ resource "bcm_cmdevice_category" "test" {
 }
 
 resource "bcm_cmdevice_device" "test" {
-  hostname           = %[6]q
-  mac                = %[8]q
-  category           = bcm_cmdevice_category.test.id
-  management_network = data.bcm_cmnet_networks.management.networks[0].id
-  notes              = "Idempotency test device"
-  kernel_parameters  = "console=ttyS0"
+  hostname          = %[6]q
+  category          = bcm_cmdevice_category.test.id
+  notes             = "Idempotency test device"
+  kernel_parameters = "console=ttyS0"
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = %[8]q
+    network  = data.bcm_cmnet_networks.management.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   depends_on = [bcm_cmdevice_category.test]
 }
@@ -595,11 +609,18 @@ resource "bcm_cmdevice_category" "test" {
 }
 
 resource "bcm_cmdevice_device" "test" {
-  hostname           = %[6]q
-  mac                = %[9]q
-  category           = bcm_cmdevice_category.test.id
-  management_network = data.bcm_cmnet_networks.management.networks[0].id
-  notes              = %[7]q
+  hostname = %[6]q
+  category = bcm_cmdevice_category.test.id
+  notes    = %[7]q
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = %[9]q
+    network  = data.bcm_cmnet_networks.management.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   depends_on = [bcm_cmdevice_category.test]
 }

--- a/internal/provider/resource_cmdevice_device_interfaces_test.go
+++ b/internal/provider/resource_cmdevice_device_interfaces_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 	"time"
 
@@ -30,7 +31,6 @@ provider "bcm" {
 
 resource "bcm_cmdevice_device" "test" {
   hostname = %[4]q
-  mac      = %[5]q
   category = %[6]q
 
   interfaces {
@@ -65,7 +65,6 @@ provider "bcm" {
 
 resource "bcm_cmdevice_device" "test" {
   hostname = %[4]q
-  mac      = %[5]q
   category = %[7]q
 
   interfaces {
@@ -111,7 +110,6 @@ provider "bcm" {
 
 resource "bcm_cmdevice_device" "test" {
   hostname = %[4]q
-  mac      = %[5]q
   category = %[6]q
 
   interfaces {
@@ -148,7 +146,6 @@ provider "bcm" {
 
 resource "bcm_cmdevice_device" "test" {
   hostname = %[4]q
-  mac      = %[5]q
   category = %[6]q
 
   interfaces {
@@ -751,7 +748,6 @@ provider "bcm" {
 
 resource "bcm_cmdevice_device" "test" {
   hostname = %[4]q
-  mac      = %[5]q
   category = %[6]q
 
   interfaces {
@@ -775,9 +771,35 @@ resource "bcm_cmdevice_device" "test" {
 	)
 }
 
-// TestAccCMDeviceDevice_LegacyMACOnly tests backward compatibility with existing configurations.
-// This test ensures that configurations without the interfaces block still work.
-func TestAccCMDeviceDevice_LegacyMACOnly(t *testing.T) {
+// TestAccCMDeviceDevice_InterfacesRequired tests that omitting the interfaces block
+// produces a validation error. ValidateConfig rejects configs with zero interfaces.
+func TestAccCMDeviceDevice_InterfacesRequired(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+provider "bcm" {
+  endpoint             = "https://localhost:8081"
+  username             = "test"
+  password             = "test"
+  insecure_skip_verify = true
+}
+
+resource "bcm_cmdevice_device" "test" {
+  hostname = "test-no-interfaces"
+  category = "12345678-1234-1234-1234-123456789012"
+}
+`),
+				ExpectError: regexp.MustCompile(`At least one interface is required`),
+			},
+		},
+	})
+}
+
+// TestAccCMDeviceDevice_SingleInterface tests creating a device with a single interface block.
+// This test ensures that the interfaces block is properly handled.
+func TestAccCMDeviceDevice_SingleInterface(t *testing.T) {
 	hostname := generateShortTestName("tftest-dev")
 	mac := generateUniqueMAC()
 
@@ -797,9 +819,9 @@ func TestAccCMDeviceDevice_LegacyMACOnly(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckCMDeviceDeviceDestroy,
 		Steps: []resource.TestStep{
-			// Step 1: Create with legacy mac-only configuration (no interfaces block)
+			// Step 1: Create with single interface configuration
 			{
-				Config: testAccCMDeviceDeviceConfigLegacy(hostname, mac, categoryUUID, networkUUID),
+				Config: testAccCMDeviceDeviceConfigSingleInterface(hostname, mac, categoryUUID, networkUUID),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"bcm_cmdevice_device.test",
@@ -829,7 +851,7 @@ func TestAccCMDeviceDevice_LegacyMACOnly(t *testing.T) {
 			},
 			// Step 2: Idempotency check
 			{
-				Config: testAccCMDeviceDeviceConfigLegacy(hostname, mac, categoryUUID, networkUUID),
+				Config: testAccCMDeviceDeviceConfigSingleInterface(hostname, mac, categoryUUID, networkUUID),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectEmptyPlan(),
@@ -846,8 +868,8 @@ func TestAccCMDeviceDevice_LegacyMACOnly(t *testing.T) {
 	})
 }
 
-// testAccCMDeviceDeviceConfigLegacy generates a config without interfaces block (legacy mode).
-func testAccCMDeviceDeviceConfigLegacy(hostname, mac, categoryUUID, networkUUID string) string {
+// testAccCMDeviceDeviceConfigSingleInterface generates a config with a single interface (converted from legacy mode).
+func testAccCMDeviceDeviceConfigSingleInterface(hostname, mac, categoryUUID, networkUUID string) string {
 	return fmt.Sprintf(`
 provider "bcm" {
   endpoint             = %[1]q
@@ -857,10 +879,17 @@ provider "bcm" {
 }
 
 resource "bcm_cmdevice_device" "test" {
-  hostname           = %[4]q
-  mac                = %[5]q
-  category           = %[6]q
-  management_network = %[7]q
+  hostname = %[4]q
+  category = %[6]q
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = %[5]q
+    network  = %[7]q
+    bootable = true
+    dhcp     = true
+  }
 }
 `,
 		os.Getenv("BCM_ENDPOINT"),

--- a/internal/provider/resource_cmdevice_device_interfaces_test.go
+++ b/internal/provider/resource_cmdevice_device_interfaces_test.go
@@ -778,7 +778,7 @@ func TestAccCMDeviceDevice_InterfacesRequired(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(`
+				Config: `
 provider "bcm" {
   endpoint             = "https://localhost:8081"
   username             = "test"
@@ -790,7 +790,7 @@ resource "bcm_cmdevice_device" "test" {
   hostname = "test-no-interfaces"
   category = "12345678-1234-1234-1234-123456789012"
 }
-`),
+`,
 				ExpectError: regexp.MustCompile(`At least one interface is required`),
 			},
 		},

--- a/internal/provider/resource_cmdevice_device_mock_test.go
+++ b/internal/provider/resource_cmdevice_device_mock_test.go
@@ -1203,10 +1203,17 @@ provider "bcm" {
 }
 
 resource "bcm_cmdevice_device" "test" {
-  hostname           = %[2]q
-  mac                = "00:11:22:33:44:55"
-  category           = "12345678-1234-1234-1234-123456789012"
-  management_network = "12345678-1234-1234-1234-123456789012"
+  hostname = %[2]q
+  category = "12345678-1234-1234-1234-123456789012"
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = "00:11:22:33:44:55"
+    network  = "12345678-1234-1234-1234-123456789012"
+    bootable = true
+    dhcp     = true
+  }
 }
 `,
 		mockEndpoint,

--- a/internal/provider/resource_cmdevice_device_test.go
+++ b/internal/provider/resource_cmdevice_device_test.go
@@ -213,10 +213,17 @@ resource "bcm_cmdevice_category" "test" {
 }
 
 resource "bcm_cmdevice_device" "test" {
-  hostname           = %[7]q
-  mac                = %[8]q
-  category           = bcm_cmdevice_category.test.id
-  management_network = data.bcm_cmnet_networks.management.networks[0].id
+  hostname = %[7]q
+  category = bcm_cmdevice_category.test.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = %[8]q
+    network  = data.bcm_cmnet_networks.management.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   depends_on = [bcm_cmdevice_category.test]
 }
@@ -265,12 +272,19 @@ resource "bcm_cmdevice_category" "test" {
 }
 
 resource "bcm_cmdevice_device" "test" {
-  hostname           = %[7]q
-  mac                = %[8]q
-  category           = bcm_cmdevice_category.test.id
-  management_network = data.bcm_cmnet_networks.management.networks[0].id
-  notes              = "Updated device notes"
-  kernel_parameters  = "quiet splash"
+  hostname          = %[7]q
+  category          = bcm_cmdevice_category.test.id
+  notes             = "Updated device notes"
+  kernel_parameters = "quiet splash"
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = %[8]q
+    network  = data.bcm_cmnet_networks.management.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   depends_on = [bcm_cmdevice_category.test]
 }
@@ -460,11 +474,18 @@ resource "bcm_cmdevice_category" "test" {
 }
 
 resource "bcm_cmdevice_device" "test" {
-  hostname           = %[7]q
-  mac                = %[8]q
-  category           = bcm_cmdevice_category.test.id
-  management_network = data.bcm_cmnet_networks.management.networks[0].id
-  notes              = "initial-notes"
+  hostname = %[7]q
+  category = bcm_cmdevice_category.test.id
+  notes    = "initial-notes"
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = %[8]q
+    network  = data.bcm_cmnet_networks.management.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   depends_on = [bcm_cmdevice_category.test]
 }
@@ -868,10 +889,17 @@ resource "bcm_cmdevice_category" "test" {
 }
 
 resource "bcm_cmdevice_device" "test" {
-  hostname           = %[5]q
-  mac                = %[6]q
-  category           = bcm_cmdevice_category.test.id
-  management_network = data.bcm_cmnet_networks.management.networks[0].id
+  hostname = %[5]q
+  category = bcm_cmdevice_category.test.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = %[6]q
+    network  = data.bcm_cmnet_networks.management.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   depends_on = [bcm_cmdevice_category.test]
 }
@@ -906,10 +934,17 @@ locals {
 }
 
 resource "bcm_cmdevice_device" "test" {
-  hostname           = %[4]q
-  mac                = %[5]q
-  category           = local.category_uuid
-  management_network = local.network_uuid
+  hostname = %[4]q
+  category = local.category_uuid
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = %[5]q
+    network  = local.network_uuid
+    bootable = true
+    dhcp     = true
+  }
 }
 `,
 		os.Getenv("BCM_ENDPOINT"),
@@ -1399,11 +1434,18 @@ resource "bcm_cmdevice_category" "test" {
 }
 
 resource "bcm_cmdevice_device" "test" {
-  hostname           = %[7]q
-  mac                = %[8]q
-  category           = bcm_cmdevice_category.test.id
-  management_network = data.bcm_cmnet_networks.management.networks[0].id
+  hostname = %[7]q
+  category = bcm_cmdevice_category.test.id
   %[9]s
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = %[8]q
+    network  = data.bcm_cmnet_networks.management.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   depends_on = [bcm_cmdevice_category.test]
 }
@@ -1452,10 +1494,17 @@ resource "bcm_cmdevice_category" "test" {
 }
 
 resource "bcm_cmdevice_device" "test" {
-  hostname           = %[7]q
-  mac                = %[8]q
-  category           = bcm_cmdevice_category.test.id
-  management_network = data.bcm_cmnet_networks.management.networks[0].id
+  hostname = %[7]q
+  category = bcm_cmdevice_category.test.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = %[8]q
+    network  = data.bcm_cmnet_networks.management.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   depends_on = [bcm_cmdevice_category.test]
 }
@@ -1960,11 +2009,18 @@ resource "bcm_cmdevice_category" "test" {
 }
 
 resource "bcm_cmdevice_device" "test" {
-  hostname           = %[7]q
-  mac                = %[8]q
-  category           = bcm_cmdevice_category.test.id
-  management_network = data.bcm_cmnet_networks.management.networks[0].id
-  roles              = %[9]s
+  hostname = %[7]q
+  category = bcm_cmdevice_category.test.id
+  roles    = %[9]s
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = %[8]q
+    network  = data.bcm_cmnet_networks.management.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   depends_on = [bcm_cmdevice_category.test]
 }
@@ -2355,11 +2411,18 @@ resource "bcm_cmdevice_category" "test" {
 }
 
 resource "bcm_cmdevice_device" "test" {
-  hostname           = %[7]q
-  mac                = %[8]q
-  category           = bcm_cmdevice_category.test.id
-  management_network = data.bcm_cmnet_networks.management.networks[0].id
-  roles              = [""]
+  hostname = %[7]q
+  category = bcm_cmdevice_category.test.id
+  roles    = [""]
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = %[8]q
+    network  = data.bcm_cmnet_networks.management.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   depends_on = [bcm_cmdevice_category.test]
 }
@@ -2841,12 +2904,19 @@ resource "bcm_cmkube_cluster" "test" {
 }
 
 resource "bcm_cmdevice_device" "test" {
-  hostname           = %[9]q
-  category           = bcm_cmdevice_category.test.id
-  management_network = data.bcm_cmnet_networks.all.networks[0].id
-  mac                = %[10]q
+  hostname = %[9]q
+  category = bcm_cmdevice_category.test.id
 
   # No kubelet_role or etcd_host_role - device exists without K8s roles
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = %[10]q
+    network  = data.bcm_cmnet_networks.all.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   depends_on = [
     bcm_cmdevice_category.test,
@@ -2916,10 +2986,17 @@ resource "bcm_cmkube_cluster" "test" {
 }
 
 resource "bcm_cmdevice_device" "test" {
-  hostname           = %[9]q
-  category           = bcm_cmdevice_category.test.id
-  management_network = data.bcm_cmnet_networks.all.networks[0].id
-  mac                = %[10]q
+  hostname = %[9]q
+  category = bcm_cmdevice_category.test.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = %[10]q
+    network  = data.bcm_cmnet_networks.all.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   kubelet_role {
     kube_cluster  = bcm_cmkube_cluster.test.uuid
@@ -2986,10 +3063,17 @@ resource "bcm_cmetcd_cluster" "test" {
 }
 
 resource "bcm_cmdevice_device" "test" {
-  hostname           = %[8]q
-  category           = bcm_cmdevice_category.test.id
-  management_network = data.bcm_cmnet_networks.all.networks[0].id
-  mac                = %[9]q
+  hostname = %[8]q
+  category = bcm_cmdevice_category.test.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = %[9]q
+    network  = data.bcm_cmnet_networks.all.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   etcd_host_role {
     etcd_cluster = bcm_cmetcd_cluster.test.uuid
@@ -3059,10 +3143,17 @@ resource "bcm_cmkube_cluster" "test" {
 }
 
 resource "bcm_cmdevice_device" "test" {
-  hostname           = %[9]q
-  category           = bcm_cmdevice_category.test.id
-  management_network = data.bcm_cmnet_networks.all.networks[0].id
-  mac                = %[10]q
+  hostname = %[9]q
+  category = bcm_cmdevice_category.test.id
+
+  interfaces {
+    name     = "eth0"
+    type     = "physical"
+    mac      = %[10]q
+    network  = data.bcm_cmnet_networks.all.networks[0].id
+    bootable = true
+    dhcp     = true
+  }
 
   kubelet_role {
     kube_cluster  = bcm_cmkube_cluster.test.uuid


### PR DESCRIPTION
## Summary

Consolidates device network configuration into the `interfaces` block, making it the single source of truth for all interface and network settings. This gives users explicit, per-interface control over network assignments and ensures imported devices retain their configuration on subsequent applies.

**Breaking change**: The `interfaces` block is now required (minimum one entry). Existing configs using top-level `mac`/`management_network` need to move those values into an `interfaces` block.

## Changes

- `mac`: Required → Optional+Computed (derived from first interface when not set)
- `interfaces`: validated to require at least one entry via `ValidateConfig`
- Unified Create/Read/Update to a single interfaces-based code path
- `mac` is computed from the first interface in Create, Read, and Update
- All examples, tests, and generated docs updated

## Migration

```hcl
# Before
resource "bcm_cmdevice_device" "node" {
  hostname           = "node001"
  mac                = "00:11:22:33:44:55"
  category           = bcm_cmdevice_category.default.uuid
  management_network = bcm_cmnet_network.internal.uuid
}

# After
resource "bcm_cmdevice_device" "node" {
  hostname = "node001"
  category = bcm_cmdevice_category.default.uuid

  interfaces {
    name     = "eth0"
    type     = "physical"
    mac      = "00:11:22:33:44:55"
    network  = bcm_cmnet_network.internal.uuid
    bootable = true
    dhcp     = true
  }
}
```

## Test plan

- [x] `go build`, `go vet`, `gofmt`, `golangci-lint` — all clean
- [x] `TestAccCMDeviceDevice_InterfacesRequired` — config rejected when interfaces absent
- [x] `terraform validate` — all 5 device examples pass against built provider
- [ ] Full acceptance test suite against BCM cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)