### PR TITLE
feat: management network passthrough, validators, docs & test coverage

### DIFF
--- a/docs/resources/cmdevice_category.md
+++ b/docs/resources/cmdevice_category.md
@@ -787,7 +787,7 @@ Optional:
 
 Required:
 
-- `child_type` (String) Role type (e.g., HeadNodeRole, StorageRole, BackupRole)
+- `child_type` (String) Role type (e.g., HeadNode, ComputeNode, PhysicalNode)
 - `name` (String) Role name (e.g., headnode, storage, compute)
 
 Optional:

--- a/internal/provider/resource_cmdevice_category.go
+++ b/internal/provider/resource_cmdevice_category.go
@@ -462,6 +462,9 @@ func (r *CMDeviceCategoryResource) Schema(ctx context.Context, req resource.Sche
 			"io_scheduler": schema.StringAttribute{
 				Optional:            true,
 				MarkdownDescription: "I/O scheduler",
+				Validators: []validator.String{
+					stringvalidator.OneOf("none", "noop", "cfq", "deadline", "mq-deadline", "bfq", "kyber"),
+				},
 			},
 			"node_installer_disk": schema.BoolAttribute{
 				Optional:            true,
@@ -626,6 +629,9 @@ func (r *CMDeviceCategoryResource) Schema(ctx context.Context, req resource.Sche
 						"filesystem": schema.StringAttribute{
 							Required:            true,
 							MarkdownDescription: "Filesystem type",
+							Validators: []validator.String{
+								stringvalidator.OneOf("nfs", "ext4", "xfs", "btrfs", "tmpfs", "cifs"),
+							},
 						},
 						"mountoptions": schema.StringAttribute{
 							Optional:            true,
@@ -634,6 +640,9 @@ func (r *CMDeviceCategoryResource) Schema(ctx context.Context, req resource.Sche
 						"fsck": schema.StringAttribute{
 							Optional:            true,
 							MarkdownDescription: "Filesystem check mode",
+							Validators: []validator.String{
+								stringvalidator.OneOf("NONE", "CHECK", "REPAIR"),
+							},
 						},
 						"dump": schema.BoolAttribute{
 							Optional:            true,
@@ -732,7 +741,10 @@ func (r *CMDeviceCategoryResource) Schema(ctx context.Context, req resource.Sche
 						},
 						"child_type": schema.StringAttribute{
 							Required:            true,
-							MarkdownDescription: "Role type (e.g., HeadNodeRole, StorageRole, BackupRole)",
+							MarkdownDescription: "Role type (e.g., HeadNode, ComputeNode, PhysicalNode)",
+							Validators: []validator.String{
+								stringvalidator.OneOf("HeadNode", "ComputeNode", "PhysicalNode", "GpuNode", "DpuNode"),
+							},
 						},
 						"uuid": schema.StringAttribute{
 							Computed:            true,
@@ -839,6 +851,9 @@ func (r *CMDeviceCategoryResource) Schema(ctx context.Context, req resource.Sche
 					"leak_policy": schema.StringAttribute{
 						Optional:            true,
 						MarkdownDescription: "Leak policy",
+						Validators: []validator.String{
+							stringvalidator.OneOf("NONE", "FAN", "SHUTDOWN", "WARNING"),
+						},
 					},
 					"leak_reaction_delay": schema.Float64Attribute{
 						Optional:            true,
@@ -898,10 +913,16 @@ func (r *CMDeviceCategoryResource) Schema(ctx context.Context, req resource.Sche
 						"compute_mode": schema.StringAttribute{
 							Optional:            true,
 							MarkdownDescription: "Compute mode (Nvidia only).",
+							Validators: []validator.String{
+								stringvalidator.OneOf("DEFAULT", "EXCLUSIVE_PROCESS", "EXCLUSIVE_THREAD", "PROHIBITED"),
+							},
 						},
 						"clock_sync_boost_mode": schema.StringAttribute{
 							Optional:            true,
 							MarkdownDescription: "Clock sync boost mode among GPUs in group (Nvidia only).",
+							Validators: []validator.String{
+								stringvalidator.OneOf("NONE", "SYNC", "AUTO"),
+							},
 						},
 						"multiprocessor_clock_speed": schema.Int64Attribute{
 							Optional:            true,
@@ -942,6 +963,9 @@ func (r *CMDeviceCategoryResource) Schema(ctx context.Context, req resource.Sche
 						"power_play": schema.StringAttribute{
 							Optional:            true,
 							MarkdownDescription: "Power play mode (AMD only).",
+							Validators: []validator.String{
+								stringvalidator.OneOf("DEFAULT", "AUTO", "LOW", "MEDIUM", "HIGH"),
+							},
 						},
 						"gpu_overdrive": schema.Float64Attribute{
 							Optional:            true,

--- a/internal/provider/resource_cmdevice_device.go
+++ b/internal/provider/resource_cmdevice_device.go
@@ -415,6 +415,9 @@ func (r *CMDeviceDeviceResource) Schema(ctx context.Context, req resource.Schema
 							Optional:            true,
 							Computed:            true,
 							MarkdownDescription: "Container runtime service name (e.g., 'docker.service', 'containerd.service'). Default: 'docker.service'.",
+							Validators: []validator.String{
+								stringvalidator.OneOf("docker.service", "containerd.service", "crio.service"),
+							},
 						},
 						"max_pods": schema.Int64Attribute{
 							Optional:            true,

--- a/internal/provider/resource_cmpart_softwareimage.go
+++ b/internal/provider/resource_cmpart_softwareimage.go
@@ -155,6 +155,9 @@ func (r *CMPartSoftwareImageResource) Schema(ctx context.Context, req resource.S
 				Computed:            true,
 				Default:             stringdefault.StaticString("ttyS1"),
 				MarkdownDescription: "SOL serial port device. Defaults to `ttyS1`.",
+				Validators: []validator.String{
+					stringvalidator.OneOf("ttyS0", "ttyS1", "ttyS2", "ttyS3"),
+				},
 			},
 			"sol_speed": schema.StringAttribute{
 				Optional:            true,


### PR DESCRIPTION
## Summary

- Fix management_network passthrough — devices now correctly send the value to BCM API 
- Add `nullIfRemovedFromConfig` plan modifier for Optional+Computed management_network
- Add 26 enum validators across device, category, and softwareimage resources to prevent invalid data reaching BCM
- Create doc templates for all 7 resources to surface import, advanced, and edge-case examples
- Add import.tf examples for all resources with data source lookup patterns
- Fix boot_loader case sensitivity ("pxelinux" → "PXELINUX")
- Fix softwareimage examples to use dynamic data source lookups instead of hardcoded names
- Add `make lint` to pre-push hooks
- Make test-examples.sh portable (works locally and in CI)
- All 44 examples pass against live cluster (22 data sources + 22 resources)

## Test plan

- [x] All unit tests pass (`make test`)
- [x] GHA lint passes
- [x] All 44 example tests pass against live BCM cluster
- [x] `import_and_recategorize.tf` fully tested (plan/apply/destroy)
- [x] Pre-push hooks pass (build, vet, lint, docs)
- [x] Docs regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)