### PR TITLE
fix: clear roles before device deletion to prevent orphaned NodeRoles

### DIFF
--- a/internal/provider/resource_cmdevice_device.go
+++ b/internal/provider/resource_cmdevice_device.go
@@ -1389,6 +1389,26 @@ func (r *CMDeviceDeviceResource) Delete(ctx context.Context, req resource.Delete
 		"hostname": state.Hostname.ValueString(),
 	})
 
+	// Clear roles before deletion to prevent orphaned NodeRoles entries.
+	// BCM does not cascade-delete role assignments when a device is removed,
+	// leaving references to non-existent devices that crash the daemon on startup.
+	// See: https://github.com/hashi-demo-lab/terraform-provider-bcm/issues/125
+	deviceBody, readErr := r.Client.CallJSONRPC(ctx, "cmdevice", "getDevice", state.UUID.ValueString())
+	if readErr == nil && len(deviceBody) > 0 {
+		var deviceData map[string]interface{}
+		if json.Unmarshal(deviceBody, &deviceData) == nil {
+			if rolesData, ok := deviceData["roles"].([]interface{}); ok && len(rolesData) > 0 {
+				tflog.Debug(ctx, "Clearing roles before device deletion", map[string]interface{}{
+					"uuid":       state.UUID.ValueString(),
+					"role_count": len(rolesData),
+				})
+				deviceData["roles"] = []interface{}{}
+				deviceData["modified"] = true
+				r.Client.CallJSONRPC(ctx, "cmdevice", "updateDevice", deviceData, true)
+			}
+		}
+	}
+
 	// Get force parameter value
 	forceValue := false
 	if !state.Force.IsNull() {

--- a/internal/provider/resource_cmdevice_device.go
+++ b/internal/provider/resource_cmdevice_device.go
@@ -1404,7 +1404,12 @@ func (r *CMDeviceDeviceResource) Delete(ctx context.Context, req resource.Delete
 				})
 				deviceData["roles"] = []interface{}{}
 				deviceData["modified"] = true
-				r.Client.CallJSONRPC(ctx, "cmdevice", "updateDevice", deviceData, true)
+				if _, updateErr := r.Client.CallJSONRPC(ctx, "cmdevice", "updateDevice", deviceData, true); updateErr != nil {
+					tflog.Warn(ctx, "Failed to clear roles before deletion, proceeding anyway", map[string]interface{}{
+						"uuid":  state.UUID.ValueString(),
+						"error": updateErr.Error(),
+					})
+				}
 			}
 		}
 	}

--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -1075,7 +1075,6 @@ cleanup_resources() {
 
     # Extract test devices (hostnames with citest- or tftest- prefix)
     local test_device_uuids=()
-    local test_device_names=()
     # Parse JSON array - each device has uuid and hostname
     while IFS= read -r uuid; do
         test_device_uuids+=("$uuid")
@@ -1101,7 +1100,8 @@ except: pass
                 -d "{\"service\":\"cmdevice\",\"call\":\"getDevice\",\"args\":[\"$dev_uuid\"]}")
 
             # Clear roles if present (prevents orphaned NodeRoles on deletion)
-            if echo "$dev_data" | python3 -c "
+            local cleared_entity
+            cleared_entity=$(echo "$dev_data" | python3 -c "
 import sys, json
 try:
     d = json.load(sys.stdin)
@@ -1110,21 +1110,12 @@ try:
         d['modified'] = True
         print(json.dumps(d))
 except: pass
-" 2>/dev/null | grep -q '{'; then
-                local cleared_entity
-                cleared_entity=$(echo "$dev_data" | python3 -c "
-import sys, json
-d = json.load(sys.stdin)
-d['roles'] = []
-d['modified'] = True
-print(json.dumps(d))
 " 2>/dev/null)
-                if [ -n "$cleared_entity" ]; then
-                    log_debug "  Clearing roles on device $dev_uuid before deletion"
-                    curl -k -s -b "$cookie_file" -X POST "${BCM_ENDPOINT}/json" \
-                        -H "Content-Type: application/json" \
-                        -d "{\"service\":\"cmdevice\",\"call\":\"updateDevice\",\"args\":[$cleared_entity, true]}" > /dev/null 2>&1
-                fi
+            if [ -n "$cleared_entity" ]; then
+                log_debug "  Clearing roles on device $dev_uuid before deletion"
+                curl -k -s -b "$cookie_file" -X POST "${BCM_ENDPOINT}/json" \
+                    -H "Content-Type: application/json" \
+                    -d "{\"service\":\"cmdevice\",\"call\":\"updateDevice\",\"args\":[$cleared_entity, true]}" > /dev/null 2>&1
             fi
 
             # Delete the device

--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -1066,6 +1066,81 @@ cleanup_resources() {
     local cleanup_success=0
     local cleanup_failed=0
 
+    # Cleanup test devices first (before categories, since categories may have dependent devices)
+    # Clear roles before deletion to prevent orphaned NodeRoles entries that crash BCM daemon
+    # See: https://github.com/hashi-demo-lab/terraform-provider-bcm/issues/125
+    log_info "Cleaning up test devices..."
+    local devices_response
+    devices_response=$(query_test_resources "$cookie_file" "cmdevice" "getNodes")
+
+    # Extract test devices (hostnames with citest- or tftest- prefix)
+    local test_device_uuids=()
+    local test_device_names=()
+    # Parse JSON array - each device has uuid and hostname
+    while IFS= read -r uuid; do
+        test_device_uuids+=("$uuid")
+    done < <(echo "$devices_response" | python3 -c "
+import sys, json
+try:
+    nodes = json.load(sys.stdin)
+    for n in nodes:
+        h = n.get('hostname','')
+        if h.startswith('citest-') or h.startswith('tftest-'):
+            print(n.get('uuid',''))
+except: pass
+" 2>/dev/null)
+
+    if [ ${#test_device_uuids[@]} -gt 0 ]; then
+        log_info "Found ${#test_device_uuids[@]} test device(s) to cleanup"
+
+        for dev_uuid in "${test_device_uuids[@]}"; do
+            # Read device to check for roles
+            local dev_data
+            dev_data=$(curl -k -s -b "$cookie_file" -X POST "${BCM_ENDPOINT}/json" \
+                -H "Content-Type: application/json" \
+                -d "{\"service\":\"cmdevice\",\"call\":\"getDevice\",\"args\":[\"$dev_uuid\"]}")
+
+            # Clear roles if present (prevents orphaned NodeRoles on deletion)
+            if echo "$dev_data" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    if d.get('roles') and len(d['roles']) > 0:
+        d['roles'] = []
+        d['modified'] = True
+        print(json.dumps(d))
+except: pass
+" 2>/dev/null | grep -q '{'; then
+                local cleared_entity
+                cleared_entity=$(echo "$dev_data" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+d['roles'] = []
+d['modified'] = True
+print(json.dumps(d))
+" 2>/dev/null)
+                if [ -n "$cleared_entity" ]; then
+                    log_debug "  Clearing roles on device $dev_uuid before deletion"
+                    curl -k -s -b "$cookie_file" -X POST "${BCM_ENDPOINT}/json" \
+                        -H "Content-Type: application/json" \
+                        -d "{\"service\":\"cmdevice\",\"call\":\"updateDevice\",\"args\":[$cleared_entity, true]}" > /dev/null 2>&1
+                fi
+            fi
+
+            # Delete the device
+            log_debug "  Deleting device $dev_uuid"
+            curl -k -s -b "$cookie_file" -X POST "${BCM_ENDPOINT}/json" \
+                -H "Content-Type: application/json" \
+                -d "{\"service\":\"cmdevice\",\"call\":\"removeDevice\",\"args\":[\"$dev_uuid\", true]}" > /dev/null 2>&1
+        done
+
+        sleep 2  # Wait for eventual consistency
+        log_pass "  ✓ Deleted ${#test_device_uuids[@]} device(s)"
+        cleanup_success=$((cleanup_success + ${#test_device_uuids[@]}))
+    else
+        log_info "No test devices found"
+    fi
+
     # Cleanup software images (from resource examples)
     log_info "Cleaning up test software images..."
     local images_response


### PR DESCRIPTION
## Summary

BCM does not cascade-delete role assignments when a device is removed. Orphaned `NodeRoles` entries cause the BCM daemon to crash on startup with `EntityStorageController, failed to convert`.

## Changes

- **Device `Delete()`**: Before calling `removeDevice`, read the device and clear its roles via `updateDevice` if any are present
- **`test-examples.sh`**: Added device cleanup phase that clears roles before deletion, runs before category/image cleanup

## Test plan

- [x] `go build`, `go vet`, `golangci-lint` pass
- [x] Pre-commit hooks pass
- [ ] Full acceptance test suite

Fixes #125