### PR TITLE
fix: clean import and plan output for device resource

### DIFF
--- a/internal/provider/plan_modifiers.go
+++ b/internal/provider/plan_modifiers.go
@@ -1,0 +1,42 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// useStateForUnknownUnlessNull returns a plan modifier that copies the prior
+// state value into the plan when state exists. Unlike UseStateForUnknown(),
+// this handles the import case gracefully: when there is no prior state
+// (e.g., import+apply in one operation), the value stays unknown rather than
+// being forced to null, avoiding "inconsistent result after apply" errors.
+func useStateForUnknownUnlessNull() planmodifier.String {
+	return useStateForUnknownUnlessNullModifier{}
+}
+
+type useStateForUnknownUnlessNullModifier struct{}
+
+func (m useStateForUnknownUnlessNullModifier) Description(_ context.Context) string {
+	return "Copies the prior state value during plan when state exists, but allows unknown during import."
+}
+
+func (m useStateForUnknownUnlessNullModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m useStateForUnknownUnlessNullModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// If there's no prior state value, let the plan value stay as-is (unknown).
+	// This handles import where there's no state yet.
+	if req.StateValue.IsNull() {
+		return
+	}
+
+	// If the plan value is unknown and we have a prior state value, use it.
+	if resp.PlanValue.IsUnknown() {
+		resp.PlanValue = req.StateValue
+	}
+}

--- a/internal/provider/resource_cmdevice_device.go
+++ b/internal/provider/resource_cmdevice_device.go
@@ -1771,8 +1771,11 @@ func (r *CMDeviceDeviceResource) parseDeviceFromAPI(data map[string]interface{})
 		model.Hostname = types.StringValue(hostname)
 	}
 
-	if mac, ok := data["mac"].(string); ok {
+	// BCM returns "00:00:00:00:00:00" as default MAC — treat as "not set".
+	if mac, ok := data["mac"].(string); ok && mac != "" && mac != "00:00:00:00:00:00" {
 		model.MAC = types.StringValue(mac)
+	} else {
+		model.MAC = types.StringNull()
 	}
 
 	if category, ok := data["category"].(string); ok {
@@ -1845,15 +1848,17 @@ func (r *CMDeviceDeviceResource) parseDeviceFromAPI(data map[string]interface{})
 	}
 
 	// Network gateway configuration
-	if defaultGateway, ok := data["defaultGateway"].(string); ok && defaultGateway != "" {
+	// BCM returns "0.0.0.0" as the default — treat as "not set" to avoid noise in state.
+	if defaultGateway, ok := data["defaultGateway"].(string); ok && defaultGateway != "" && defaultGateway != "0.0.0.0" {
 		model.DefaultGateway = types.StringValue(defaultGateway)
 	} else {
 		model.DefaultGateway = types.StringNull()
 	}
 
-	if defaultGatewayMetric, ok := data["defaultGatewayMetric"].(float64); ok {
+	// BCM returns 0 as the default metric — treat as "not set".
+	if defaultGatewayMetric, ok := data["defaultGatewayMetric"].(float64); ok && defaultGatewayMetric != 0 {
 		model.DefaultGatewayMetric = types.Int64Value(int64(defaultGatewayMetric))
-	} else if defaultGatewayMetricInt, ok := data["defaultGatewayMetric"].(int64); ok {
+	} else if defaultGatewayMetricInt, ok := data["defaultGatewayMetric"].(int64); ok && defaultGatewayMetricInt != 0 {
 		model.DefaultGatewayMetric = types.Int64Value(defaultGatewayMetricInt)
 	} else {
 		model.DefaultGatewayMetric = types.Int64Null()

--- a/internal/provider/resource_cmdevice_device.go
+++ b/internal/provider/resource_cmdevice_device.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -184,6 +185,9 @@ func (r *CMDeviceDeviceResource) Schema(ctx context.Context, req resource.Schema
 				Optional:            true,
 				Computed:            true,
 				MarkdownDescription: "Boot loader type (e.g., SYSLINUX, GRUB) - defaults to category value",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 				Validators: []validator.String{
 					stringvalidator.OneOf("SYSLINUX", "GRUB"),
 				},
@@ -192,6 +196,9 @@ func (r *CMDeviceDeviceResource) Schema(ctx context.Context, req resource.Schema
 				Optional:            true,
 				Computed:            true,
 				MarkdownDescription: "Boot loader protocol (e.g., HTTP, TFTP) - defaults to category value",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 				Validators: []validator.String{
 					stringvalidator.OneOf("HTTP", "TFTP"),
 				},
@@ -221,28 +228,46 @@ func (r *CMDeviceDeviceResource) Schema(ctx context.Context, req resource.Schema
 				Optional:            true,
 				Computed:            true,
 				MarkdownDescription: "Default gateway metric/priority (lower is preferred)",
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 			},
 			"serial_number": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				MarkdownDescription: "Hardware serial number",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"part_number": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				MarkdownDescription: "Hardware part number",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"creation_time": schema.Int64Attribute{
 				Computed:            true,
 				MarkdownDescription: "Device creation timestamp (Unix epoch)",
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 			},
 			"base_type": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Entity base type (always 'Device')",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"child_type": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Device type (HeadNode, ComputeNode, PhysicalNode, etc.)",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"roles": schema.SetAttribute{
 				Optional:    true,

--- a/internal/provider/resource_cmdevice_device.go
+++ b/internal/provider/resource_cmdevice_device.go
@@ -109,10 +109,16 @@ func (r *CMDeviceDeviceResource) Schema(ctx context.Context, req resource.Schema
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Device identifier (same as UUID)",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"uuid": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Device UUID assigned by BCM",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"hostname": schema.StringAttribute{
 				Required:            true,

--- a/internal/provider/resource_cmdevice_device.go
+++ b/internal/provider/resource_cmdevice_device.go
@@ -391,18 +391,30 @@ func (r *CMDeviceDeviceResource) Schema(ctx context.Context, req resource.Schema
 						"uuid": schema.StringAttribute{
 							Computed:            true,
 							MarkdownDescription: "BCM-assigned interface UUID.",
+							PlanModifiers: []planmodifier.String{
+								useStateForUnknownUnlessNull(),
+							},
 						},
 						"base_type": schema.StringAttribute{
 							Computed:            true,
 							MarkdownDescription: "Entity base type (always 'NetworkInterface').",
+							PlanModifiers: []planmodifier.String{
+								useStateForUnknownUnlessNull(),
+							},
 						},
 						"child_type": schema.StringAttribute{
 							Computed:            true,
 							MarkdownDescription: "Interface type (NetworkPhysicalInterface, NetworkBondInterface, NetworkBMCInterface).",
+							PlanModifiers: []planmodifier.String{
+								useStateForUnknownUnlessNull(),
+							},
 						},
 						"cardtype": schema.StringAttribute{
 							Computed:            true,
 							MarkdownDescription: "Hardware card type (Ethernet, InfiniBand, BMC).",
+							PlanModifiers: []planmodifier.String{
+								useStateForUnknownUnlessNull(),
+							},
 						},
 					},
 				},

--- a/test-impot/README.md
+++ b/test-impot/README.md
@@ -1,0 +1,91 @@
+# Test: Import and Config Generation
+
+Demonstrates importing an existing BCM device into Terraform using
+`terraform plan -generate-config-out` (Terraform 1.5+).
+
+## Prerequisites
+
+```bash
+# Provider must be built and installed
+make install
+
+# dev_overrides must be configured in ~/.terraformrc:
+# provider_installation {
+#   dev_overrides {
+#     "hashicorp/bcm" = "/Users/simon.lynch/go/bin"
+#   }
+#   direct {}
+# }
+```
+
+## Step 1: Find the device UUID
+
+```bash
+cd test-impot
+
+# Create a lookup config
+cat > lookup.tf <<'EOF'
+data "bcm_cmdevice_nodes" "all" {}
+
+output "devices" {
+  value = [for n in data.bcm_cmdevice_nodes.all.nodes : "${n.id}  ${n.hostname}  ${n.child_type}"]
+}
+EOF
+
+terraform apply -auto-approve
+# Pick a UUID from the output, then clean up:
+rm lookup.tf terraform.tfstate
+```
+
+## Step 2: Create the import block
+
+```bash
+cat > import.tf <<'EOF'
+import {
+  to = bcm_cmdevice_device.example
+  id = "<device-uuid-from-step-1>"
+}
+EOF
+```
+
+## Step 3: Generate config
+
+```bash
+terraform plan -generate-config-out=generated.tf
+```
+
+This connects to BCM, reads the device, and generates `generated.tf` with
+the full resource configuration. Review the output — BCM sentinel values
+(`0.0.0.0`, `00:00:00:00:00:00`, zero UUID) are mapped to null automatically.
+
+## Step 4: Apply the import
+
+```bash
+terraform apply
+```
+
+The device is now in Terraform state with 0 changes.
+
+## Step 5: Clean up and use
+
+```bash
+# Remove the import block (no longer needed)
+rm import.tf
+
+# Edit generated.tf — remove null lines, use data sources for UUIDs:
+#   category = data.bcm_cmdevice_categories.example.categories[0].id
+
+# Verify idempotency
+terraform plan
+# Should show: No changes. Your infrastructure matches the configuration.
+```
+
+## Notes
+
+- The `provider.tf` uses `hashicorp/bcm` source to match `dev_overrides`.
+  For production, use `hashi-demo-lab/bcm` with a version constraint.
+- Generated config includes `= null` for all unset Optional attributes.
+  This is standard Terraform behavior — remove them for cleaner config.
+- BCM returns `"CATEGORY"` for `boot_loader` and `boot_loader_protocol`
+  on devices inheriting from their category. The provider maps these to
+  null so they don't appear in generated config or cause validator errors.


### PR DESCRIPTION
## Summary

Improve the device resource import and plan UX by eliminating noisy `(known after apply)` output and mapping BCM default sentinels to null.

## Changes

### UseStateForUnknown plan modifiers
- Added `UseStateForUnknown()` to device `id`, `uuid`, `boot_loader`, `boot_loader_protocol`, `default_gateway_metric`, `serial_number`, `part_number`, `creation_time`, `base_type`, `child_type`
- These Computed fields are stable across updates and should carry forward from state

### Custom plan modifier for nested computed fields
- Added `useStateForUnknownUnlessNull()` in `plan_modifiers.go` — copies prior state during plan when available, but allows unknown during import (no prior state)
- Applied to interface computed fields: `uuid`, `base_type`, `child_type`, `cardtype`
- Solves the trade-off: `UseStateForUnknown` breaks import with "inconsistent result after apply", but without it updates show noise

### BCM sentinel-to-null mapping
- `default_gateway`: `"0.0.0.0"` → null
- `default_gateway_metric`: `0` → null
- `mac`: `"00:00:00:00:00:00"` → null
- Prevents BCM defaults from appearing in state and generated config

### Before → After (plan output for category change)

**Before:**
```
~ base_type  = "Device" -> (known after apply)
+ boot_loader = (known after apply)
+ boot_loader_protocol = (known after apply)
~ category = "..." -> "..."
~ child_type = "PhysicalNode" -> (known after apply)
~ creation_time = 1775104510 -> (known after apply)
~ id = "..." -> (known after apply)
+ part_number = (known after apply)
+ serial_number = (known after apply)
~ uuid = "..." -> (known after apply)
~ interfaces { ~ base_type, ~ cardtype, ~ child_type, ~ uuid ... }
```

**After:**
```
~ category = "..." -> "..."
  id = "fc0ffa21-..."
  # (9 unchanged attributes hidden)
  # (1 unchanged block hidden)
```

## Test plan

- [x] `terraform plan -generate-config-out` — clean config, no sentinel values
- [x] `terraform apply` — import succeeds with 0 changes
- [x] Category change plan — only shows category diff, no noise
- [x] `make install` / `make test` — pass
- [x] Pre-commit hooks — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)